### PR TITLE
Add voice selection to intebchat activities

### DIFF
--- a/mod/intebchat/api/completion.php
+++ b/mod/intebchat/api/completion.php
@@ -199,7 +199,9 @@ try {
     $audio_output_tokens = 0;
     if (!empty($instance->enableaudio) && $response_mode === 'audio') {
         require_once($CFG->dirroot . '/mod/intebchat/classes/audio.php');
-        $voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
+        $voice = !empty($instance->voice)
+            ? $instance->voice
+            : (get_config('mod_intebchat', 'voice') ?: 'alloy');
         
         // Use the enhanced speech function with tracking
         $audio_result = \mod_intebchat\audio::speech_with_tracking(strip_tags($response['message']), $voice);

--- a/mod/intebchat/backup/moodle2/backup_intebchat_stepslib.php
+++ b/mod/intebchat/backup/moodle2/backup_intebchat_stepslib.php
@@ -46,7 +46,8 @@ class backup_intebchat_activity_structure_step extends backup_activity_structure
             'sourceoftruth', 'prompt', 'instructions', 'username',
             'assistantname', 'apikey', 'model', 'temperature',
             'maxlength', 'topp', 'frequency', 'presence',
-            'assistant', 'persistconvo', 'timecreated', 'timemodified'
+            'assistant', 'persistconvo', 'enableaudio', 'audiomode', 'voice',
+            'timecreated', 'timemodified'
         ));
 
         // Define chat logs.

--- a/mod/intebchat/db/install.xml
+++ b/mod/intebchat/db/install.xml
@@ -26,6 +26,9 @@
         <FIELD NAME="presence" TYPE="number" LENGTH="10" DECIMALS="2" NOTNULL="false" SEQUENCE="false" COMMENT="Presence penalty"/>
         <FIELD NAME="assistant" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Assistant ID"/>
         <FIELD NAME="persistconvo" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Persist conversations"/>
+        <FIELD NAME="enableaudio" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Enable audio features"/>
+        <FIELD NAME="audiomode" TYPE="char" LENGTH="10" NOTNULL="true" DEFAULT="text" SEQUENCE="false" COMMENT="Audio response mode"/>
+        <FIELD NAME="voice" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="alloy" SEQUENCE="false" COMMENT="Voice for audio responses"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Timestamp of when the instance was added to the course."/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Timestamp of when the instance was last modified."/>
       </FIELDS>

--- a/mod/intebchat/db/upgrade.php
+++ b/mod/intebchat/db/upgrade.php
@@ -281,5 +281,17 @@ function xmldb_intebchat_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2025030101, 'intebchat');
     }
 
+    if ($oldversion < 2025030102) {
+        $table = new xmldb_table('intebchat');
+
+        // Add voice field.
+        $field = new xmldb_field('voice', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'alloy', 'audiomode');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_mod_savepoint(true, 2025030102, 'intebchat');
+    }
+
     return true;
 }

--- a/mod/intebchat/lib.php
+++ b/mod/intebchat/lib.php
@@ -91,13 +91,13 @@ function intebchat_add_instance(stdClass $intebchat, mod_intebchat_mod_form $mfo
     if (!isset($intebchat->persistconvo)) {
         $intebchat->persistconvo = 0;
     }
+
     if (!isset($intebchat->enableaudio)) {
         $intebchat->enableaudio = 0;
         $intebchat->audiomode = 'text';
     }
-    if (!isset($intebchat->enableaudio)) {
-        $intebchat->enableaudio = 0;
-        $intebchat->audiomode = 'text';
+    if (!isset($intebchat->voice)) {
+        $intebchat->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
     }
 
     // Clean up fields based on API type
@@ -153,6 +153,14 @@ function intebchat_update_instance(stdClass $intebchat, mod_intebchat_mod_form $
     }
     if (!isset($intebchat->persistconvo)) {
         $intebchat->persistconvo = 0;
+    }
+
+    if (!isset($intebchat->enableaudio)) {
+        $intebchat->enableaudio = 0;
+        $intebchat->audiomode = 'text';
+    }
+    if (!isset($intebchat->voice)) {
+        $intebchat->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
     }
 
     // Clean up fields based on API type

--- a/mod/intebchat/mod_form.php
+++ b/mod/intebchat/mod_form.php
@@ -87,6 +87,18 @@ class mod_intebchat_mod_form extends moodleform_mod {
             $mform->setDefault('audiomode', 'text');
             $mform->addHelpButton('audiomode', 'audiomode', 'mod_intebchat');
             $mform->disabledIf('audiomode', 'enableaudio', 'eq', 0);
+
+            $voices = [
+                'alloy' => 'Alloy',
+                'echo' => 'Echo',
+                'fable' => 'Fable',
+                'onyx' => 'Onyx',
+                'nova' => 'Nova',
+                'shimmer' => 'Shimmer',
+            ];
+            $mform->addElement('select', 'voice', get_string('voice', 'mod_intebchat'), $voices);
+            $mform->setDefault('voice', get_config('mod_intebchat', 'voice'));
+            $mform->disabledIf('voice', 'enableaudio', 'eq', 0);
         }
 
         // Hidden field for API type (always use global setting)
@@ -260,6 +272,9 @@ class mod_intebchat_mod_form extends moodleform_mod {
         // Always use global API type
         $config = get_config('mod_intebchat');
         $default_values['apitype'] = $config->type ?: 'chat';
+        if (empty($default_values['voice'])) {
+            $default_values['voice'] = get_config('mod_intebchat', 'voice');
+        }
     }
 
     /**
@@ -277,6 +292,9 @@ class mod_intebchat_mod_form extends moodleform_mod {
         // Set defaults for unchecked checkboxes
         if (!isset($data->enableaudio)) {
             $data->enableaudio = 0;
+        }
+        if (empty($data->voice)) {
+            $data->voice = get_config('mod_intebchat', 'voice');
         }
     }
 }

--- a/mod/intebchat/version.php
+++ b/mod/intebchat/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_intebchat';
-$plugin->version = 2025030102; // YYYYMMDDXX format - Incrementado para forzar actualización
+$plugin->version = 2025030103; // YYYYMMDDXX format
 $plugin->requires = 2022041900; // Moodle 4.0 minimum
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v1.1.1'; // Updated version for audio fixes
+$plugin->release = 'v1.1.2'; // Updated for voice selection support


### PR DESCRIPTION
## Summary
- Allow choosing text-to-speech voice per Intebchat instance via activity form
- Store chosen voice in database and use it for audio responses
- Include voice field in backups and plugin upgrade steps

## Testing
- `xmllint --noout mod/intebchat/db/install.xml`
- `php -l mod/intebchat/db/upgrade.php`
- `php -l mod/intebchat/version.php`
- `php -l mod/intebchat/mod_form.php`
- `php -l mod/intebchat/lib.php`
- `php -l mod/intebchat/api/completion.php`
- `php -l mod/intebchat/backup/moodle2/backup_intebchat_stepslib.php`
- `phpcs mod/intebchat/db/upgrade.php mod/intebchat/version.php mod/intebchat/mod_form.php mod/intebchat/lib.php mod/intebchat/api/completion.php mod/intebchat/backup/moodle2/backup_intebchat_stepslib.php` *(fails: Referenced sniff "moodle" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689607677cb4832ab5c903de08e628d5