### PR TITLE
feat: respect instance voice precedence

### DIFF
--- a/mod/intebchat/lib.php
+++ b/mod/intebchat/lib.php
@@ -96,12 +96,17 @@ function intebchat_add_instance(stdClass $intebchat, mod_intebchat_mod_form $mfo
         $intebchat->enableaudio = 0;
         $intebchat->audiomode = 'text';
     }
-    
-    // Handle voice parameter with proper validation and sanitization
-    if (isset($intebchat->voice) && !empty($intebchat->voice)) {
-        $intebchat->voice = clean_param($intebchat->voice, PARAM_ALPHANUMEXT);
-    }
-    if (!isset($intebchat->voice) || $intebchat->voice === '') {
+
+    // Voice precedence: instance > global, mirroring block_openai_chat.
+    if ($config->allowinstancesettings) {
+        if (isset($intebchat->voice) && !empty($intebchat->voice)) {
+            $intebchat->voice = clean_param($intebchat->voice, PARAM_ALPHANUMEXT);
+        }
+        if (!isset($intebchat->voice) || $intebchat->voice === '') {
+            $intebchat->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
+        }
+    } else {
+        // When instance settings disabled, always use global voice.
         $intebchat->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
     }
 
@@ -164,16 +169,21 @@ function intebchat_update_instance(stdClass $intebchat, mod_intebchat_mod_form $
         $intebchat->enableaudio = 0;
         $intebchat->audiomode = 'text';
     }
-    
-    // Handle voice parameter with proper validation and sanitization
-    if (isset($intebchat->voice) && !empty($intebchat->voice)) {
-        $intebchat->voice = clean_param($intebchat->voice, PARAM_ALPHANUMEXT);
-    }
-    if (!isset($intebchat->voice) || $intebchat->voice === '') {
-        // Preserve existing voice if field not submitted during update
-        $intebchat->voice = $DB->get_field('intebchat', 'voice', ['id' => $intebchat->id]);
-    }
-    if (empty($intebchat->voice)) {
+
+    // Voice precedence: instance > stored value > global.
+    if ($config->allowinstancesettings) {
+        if (isset($intebchat->voice) && !empty($intebchat->voice)) {
+            $intebchat->voice = clean_param($intebchat->voice, PARAM_ALPHANUMEXT);
+        }
+        if (!isset($intebchat->voice) || $intebchat->voice === '') {
+            // Preserve existing voice if field not submitted during update.
+            $intebchat->voice = $DB->get_field('intebchat', 'voice', ['id' => $intebchat->id]);
+        }
+        if (empty($intebchat->voice)) {
+            $intebchat->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
+        }
+    } else {
+        // Instance settings disabled - always use global voice.
         $intebchat->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
     }
 

--- a/mod/intebchat/mod_form.php
+++ b/mod/intebchat/mod_form.php
@@ -82,13 +82,13 @@ class mod_intebchat_mod_form extends moodleform_mod {
                 'audio' => get_string('audiomode_audio', 'mod_intebchat'),
                 'both' => get_string('audiomode_both', 'mod_intebchat')
             ];
-            
+
             $mform->addElement('select', 'audiomode', get_string('audiomode', 'mod_intebchat'), $audiomodes);
             $mform->setDefault('audiomode', 'text');
             $mform->addHelpButton('audiomode', 'audiomode', 'mod_intebchat');
             $mform->disabledIf('audiomode', 'enableaudio', 'eq', 0);
 
-            // Voice selection - ALWAYS VISIBLE when audio is enabled globally
+            // Voice selection: replicated from local_geniai's audio logic.
             $voices = [
                 'alloy' => 'Alloy (Neutral, professional)',
                 'echo' => 'Echo (Warm, conversational)',
@@ -97,13 +97,19 @@ class mod_intebchat_mod_form extends moodleform_mod {
                 'nova' => 'Nova (Energetic, bright)',
                 'shimmer' => 'Shimmer (Gentle, soothing)',
             ];
-            
-            $mform->addElement('select', 'voice', get_string('voice', 'mod_intebchat'), $voices);
-            // Ensure submitted value is treated as text
-            $mform->setType('voice', PARAM_ALPHANUMEXT);
-            // Use global default as default value
-            $mform->setDefault('voice', get_config('mod_intebchat', 'voice') ?: 'alloy');
-            $mform->addHelpButton('voice', 'voice', 'mod_intebchat');
+
+            if ($config->allowinstancesettings) {
+                // Instance level selector – mirrors block_openai_chat pattern.
+                $mform->addElement('select', 'voice', get_string('voice', 'mod_intebchat'), $voices);
+                $mform->setType('voice', PARAM_ALPHANUMEXT);
+                $mform->setDefault('voice', get_config('mod_intebchat', 'voice') ?: 'alloy');
+                $mform->addHelpButton('voice', 'voice', 'mod_intebchat');
+                $mform->disabledIf('voice', 'enableaudio', 'eq', 0);
+            } else {
+                // When instance settings are disabled, store the global voice silently.
+                $mform->addElement('hidden', 'voice', get_config('mod_intebchat', 'voice') ?: 'alloy');
+                $mform->setType('voice', PARAM_ALPHANUMEXT);
+            }
         }
 
         // Hidden field for API type (always use global setting)
@@ -112,7 +118,8 @@ class mod_intebchat_mod_form extends moodleform_mod {
 
         // Assistant name (common for all API types)
         $mform->addElement('text', 'assistantname', get_string('assistantname', 'mod_intebchat'));
-        $mform->setDefault('assistantname', '');
+        // Default now respects global config so instance > global precedence.
+        $mform->setDefault('assistantname', get_config('mod_intebchat', 'assistantname') ?: '');
         $mform->setType('assistantname', PARAM_TEXT);
         $mform->addHelpButton('assistantname', 'config_assistantname', 'mod_intebchat');
 
@@ -280,8 +287,11 @@ class mod_intebchat_mod_form extends moodleform_mod {
         $config = get_config('mod_intebchat');
         $default_values['apitype'] = $config->type ?: 'chat';
         
-        // Set voice default if not present
-        if (!isset($default_values['voice']) || $default_values['voice'] === '') {
+        // Voice default handling mirrors instance > global precedence.
+        if (!$config->allowinstancesettings) {
+            // Instance field hidden, always use global voice.
+            $default_values['voice'] = get_config('mod_intebchat', 'voice') ?: 'alloy';
+        } else if (!isset($default_values['voice']) || $default_values['voice'] === '') {
             $default_values['voice'] = get_config('mod_intebchat', 'voice') ?: 'alloy';
         }
     }
@@ -297,18 +307,21 @@ class mod_intebchat_mod_form extends moodleform_mod {
         // Ensure apitype is always set from global config
         $config = get_config('mod_intebchat');
         $data->apitype = $config->type ?: 'chat';
-        
+
         // Set defaults for unchecked checkboxes
         if (!isset($data->enableaudio)) {
             $data->enableaudio = 0;
         }
-        
-        // Ensure voice always has a value - Combined logic from both branches
-        if (!isset($data->voice) || $data->voice === '') {
-            // Try to get from optional_param first (for form submission)
+
+        // Voice handling – replicates custom instruction precedence.
+        if (!$config->allowinstancesettings) {
+            // Force global voice when instance settings disabled.
+            $data->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
+        } else if (!isset($data->voice) || $data->voice === '') {
+            // Try to get from optional_param first (for form submission).
             $data->voice = optional_param('voice', '', PARAM_ALPHANUMEXT);
-            
-            // If still empty, use global default
+
+            // If still empty, use global default.
             if ($data->voice === '') {
                 $data->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
             }

--- a/mod/intebchat/version.php
+++ b/mod/intebchat/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_intebchat';
-$plugin->version = 2025030200; // Incrementado para las correcciones
+$plugin->version = 2025030201; // Bump version for voice precedence fix
 $plugin->requires = 2022041900; // Moodle 4.0 minimum
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v1.2.0'; // Nueva versión con correcciones y animaciones


### PR DESCRIPTION
## Summary
- respect instance > global precedence for voice selection and hide voice field when instance settings disabled
- default assistant name to global setting
- bump module version

## Testing
- `php -l mod/intebchat/mod_form.php`
- `php -l mod/intebchat/lib.php`
- `php -l mod/intebchat/version.php`
- `vendor/bin/phpunit --testsuite mod_intebchat` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68974cfd4a30832a863caeb2e0626c73