### PR TITLE
Fix instance voice preservation for intebchat

### DIFF
--- a/mod/intebchat/mod_form.php
+++ b/mod/intebchat/mod_form.php
@@ -314,16 +314,17 @@ class mod_intebchat_mod_form extends moodleform_mod {
         }
 
         // Voice handling mirrors the instance > global precedence used in
-        // block_openai_chat. When per-instance settings are enabled we capture the
-        // submitted value (even if the form element was disabled) and fall back to
-        // the global configuration only when empty. If instance settings are
+        // block_openai_chat. When per-instance settings are enabled we only store
+        // a submitted value (even if the form element was disabled); otherwise the
+        // existing database value should persist and lib.php will fall back to the
+        // global configuration if nothing is present. When instance settings are
         // disabled the voice always comes from the global config.
         if ($config->allowinstancesettings) {
             if (!isset($data->voice)) {
-                $data->voice = optional_param('voice', '', PARAM_ALPHANUMEXT);
-            }
-            if ($data->voice === '') {
-                $data->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';
+                $submittedvoice = optional_param('voice', null, PARAM_ALPHANUMEXT);
+                if ($submittedvoice !== null && $submittedvoice !== '') {
+                    $data->voice = $submittedvoice;
+                }
             }
         } else {
             $data->voice = get_config('mod_intebchat', 'voice') ?: 'alloy';

--- a/mod/intebchat/version.php
+++ b/mod/intebchat/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_intebchat';
-$plugin->version = 2025030204; // Bump version after adjusting voice capture
+$plugin->version = 2025030205; // Bump version after preserving instance voice
 $plugin->requires = 2022041900; // Moodle 4.0 minimum
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v1.2.0'; // Nueva versión con correcciones y animaciones


### PR DESCRIPTION
## Summary
- Preserve existing voice value when editing intebchat instances
- Bump plugin version to 2025030205

## Testing
- `php -l mod/intebchat/mod_form.php mod/intebchat/version.php`
- `vendor/bin/phpcs mod/intebchat/mod_form.php mod/intebchat/version.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689761302d8c832aba4bb10c77feec62