### PR TITLE
Fix instance-level voice selection in intebchat

### DIFF
--- a/mod/intebchat/api/completion.php
+++ b/mod/intebchat/api/completion.php
@@ -119,6 +119,7 @@ $setting_names = [
     'prompt',
     'instructions',
     'assistantname',
+    'voice',
     'apikey',
     'model',
     'temperature',
@@ -199,10 +200,10 @@ try {
     $audio_output_tokens = 0;
     if (!empty($instance->enableaudio) && $response_mode === 'audio') {
         require_once($CFG->dirroot . '/mod/intebchat/classes/audio.php');
-        
-        // IMPORTANTE: Usar la voz de la instancia, no la global
-        $voice = !empty($instance->voice) ? $instance->voice : 'alloy';
-        
+
+        // IMPORTANTE: Usar la voz obtenida tras combinar configuración global e instancia
+        $voice = $completion->get_voice() ?? 'alloy';
+
         // Use the enhanced speech function with tracking
         $audio_result = \mod_intebchat\audio::speech_with_tracking(strip_tags($response['message']), $voice);
         

--- a/mod/intebchat/classes/completion.php
+++ b/mod/intebchat/classes/completion.php
@@ -45,6 +45,7 @@ class completion {
 
     protected $assistant;
     protected $instructions;
+    protected $voice;
 
     /**
      * Initialize all the class properties that we'll need regardless of model
@@ -78,6 +79,7 @@ class completion {
 
         $this->assistant = $this->get_setting('assistant');
         $this->instructions = $this->get_setting('instructions');
+        $this->voice = $this->get_setting('voice', 'alloy');
 
         // Then override with instance settings if applicable
         if (get_config('mod_intebchat', 'allowinstancesettings') === "1") {
@@ -92,6 +94,14 @@ class completion {
         $this->history = $history;
 
         $this->build_source_of_truth($instance_settings['sourceoftruth']);
+    }
+
+    /**
+     * Get the voice to use for audio responses
+     * @return string
+     */
+    public function get_voice() {
+        return $this->voice;
     }
 
     /**

--- a/mod/intebchat/mod_form.php
+++ b/mod/intebchat/mod_form.php
@@ -101,6 +101,7 @@ class mod_intebchat_mod_form extends moodleform_mod {
             $mform->addElement('select', 'voice', get_string('voice', 'mod_intebchat'), $voices);
             // Use global default as default value
             $mform->setDefault('voice', get_config('mod_intebchat', 'voice') ?: 'alloy');
+            $mform->setType('voice', PARAM_TEXT);
             $mform->addHelpButton('voice', 'voice', 'mod_intebchat');
             // Only disable if audio is disabled for this instance
             $mform->disabledIf('voice', 'enableaudio', 'eq', 0);


### PR DESCRIPTION
## Summary
- ensure voice field from mod_form is saved as text
- merge global and instance voice settings and use them for audio replies

## Testing
- `php -l mod/intebchat/mod_form.php`
- `php -l mod/intebchat/api/completion.php`
- `php -l mod/intebchat/classes/completion.php`


------
https://chatgpt.com/codex/tasks/task_e_689a1cd5078c832a9b7b17f1ffcec298