### PR TITLE
feat: move download center to system context

### DIFF
--- a/local/downloadcenter/course_select_form.php
+++ b/local/downloadcenter/course_select_form.php
@@ -15,19 +15,26 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * @package   local_downloadcenter
- * @author    Simeon Naydenov
- * @copyright 2020 Academic Moodle Cooperation {@link http://www.academic-moodle-cooperation.org}
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Course selection form for download center.
+ *
+ * @package       local_downloadcenter
+ * @author        ChatGPT
+ * @license       http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024010100;
-$plugin->requires  = 2022112800;
-$plugin->component = 'local_downloadcenter';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = "v4.1.1";
+require_once($CFG->libdir . '/formslib.php');
+require_once($CFG->dirroot . '/course/lib.php');
 
+class local_downloadcenter_course_select_form extends moodleform {
+    public function definition() {
+        $mform = $this->_form;
+
+        $courses = get_courses_menu();
+        $mform->addElement('select', 'courseid', get_string('course'), $courses);
+        $mform->setType('courseid', PARAM_INT);
+
+        $this->add_action_buttons(true, get_string('continue'));
+    }
+}

--- a/local/downloadcenter/db/access.php
+++ b/local/downloadcenter/db/access.php
@@ -28,11 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 $capabilities = array(
     'local/downloadcenter:view' => array(
         'captype' => 'read',
-        'contextlevel' => CONTEXT_COURSE,
+        'contextlevel' => CONTEXT_SYSTEM,
         'archetypes' => array(
-            'student' => CAP_ALLOW,
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW
         )
     ),

--- a/local/downloadcenter/settings.php
+++ b/local/downloadcenter/settings.php
@@ -26,6 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
+    $ADMIN->add('localplugins', new admin_externalpage('local_downloadcenter_index',
+        get_string('navigationlink', 'local_downloadcenter'), new moodle_url('/local/downloadcenter/index.php')));
 
     $settings = new admin_settingpage('local_downloadcenter', get_string('settings_title', 'local_downloadcenter'));
     $ADMIN->add('localplugins', $settings);


### PR DESCRIPTION
## Summary
- expose download center at site level with course selection form
- restrict capability to managers at system context
- skip student submissions when downloading assignments

## Testing
- `php -l local/downloadcenter/db/access.php`
- `php -l local/downloadcenter/index.php`
- `php -l local/downloadcenter/locallib.php`
- `php -l local/downloadcenter/version.php`
- `php -l local/downloadcenter/course_select_form.php`
- `php -l local/downloadcenter/settings.php`
- `vendor/bin/phpunit local/downloadcenter/tests/files_visible_test.php` *(fails: require(config.php) missing)*


------
https://chatgpt.com/codex/tasks/task_e_689a6c5fb580832aa059cb4ba94006cd