### PR TITLE
feat: move download center to system context

### DIFF
--- a/local/downloadcenter/course_select_form.php
+++ b/local/downloadcenter/course_select_form.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of local_downloadcenter for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Course selection form for download center.
+ *
+ * @package       local_downloadcenter
+ * @author        ChatGPT
+ * @license       http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+require_once($CFG->dirroot . '/course/lib.php');
+
+class local_downloadcenter_course_select_form extends moodleform {
+    public function definition() {
+        $mform = $this->_form;
+
+        $options = [];
+        $courses = \core_course_category::top()->get_courses([
+            'recursive' => true,
+            'sort' => ['fullname' => 1],
+        ]);
+        foreach ($courses as $course) {
+            $options[$course->id] = $course->get_formatted_name();
+        }
+
+        $mform->addElement('select', 'courseid', get_string('course'), $options);
+        $mform->setType('courseid', PARAM_INT);
+
+        $buttonarray = [];
+        $buttonarray[] = $mform->createElement('submit', 'downloadall',
+            get_string('downloadall', 'local_downloadcenter'));
+        $buttonarray[] = $mform->createElement('submit', 'submitbutton',
+            get_string('selectfiles', 'local_downloadcenter'));
+        $mform->addGroup($buttonarray, 'buttons', '', [' '], false);
+    }
+}

--- a/local/downloadcenter/db/access.php
+++ b/local/downloadcenter/db/access.php
@@ -28,11 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 $capabilities = array(
     'local/downloadcenter:view' => array(
         'captype' => 'read',
-        'contextlevel' => CONTEXT_COURSE,
+        'contextlevel' => CONTEXT_SYSTEM,
         'archetypes' => array(
-            'student' => CAP_ALLOW,
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW
         )
     ),

--- a/local/downloadcenter/lang/en/local_downloadcenter.php
+++ b/local/downloadcenter/lang/en/local_downloadcenter.php
@@ -50,3 +50,5 @@ $string['untitled'] = 'Untitled';
 $string['privacy:null_reason'] = 'This plugin does not store or process any personal information. It presents an interface to download all course files which are manipulated from within the course.';
 
 $string['no_downloadable_content'] = 'No downloadable content';
+$string['downloadall'] = 'Download all';
+$string['selectfiles'] = 'Select files';

--- a/local/downloadcenter/settings.php
+++ b/local/downloadcenter/settings.php
@@ -26,6 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
+    $ADMIN->add('localplugins', new admin_externalpage('local_downloadcenter_index',
+        get_string('navigationlink', 'local_downloadcenter'), new moodle_url('/local/downloadcenter/index.php')));
 
     $settings = new admin_settingpage('local_downloadcenter', get_string('settings_title', 'local_downloadcenter'));
     $ADMIN->add('localplugins', $settings);

--- a/local/downloadcenter/version.php
+++ b/local/downloadcenter/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022120700;
+$plugin->version   = 2024010100;
 $plugin->requires  = 2022112800;
 $plugin->component = 'local_downloadcenter';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = "v4.1.0";
+$plugin->release   = "v4.1.1";
 


### PR DESCRIPTION
## Summary
- expose download center at site level with course selection form
- restrict capability to managers at system context
- skip student submissions when downloading assignments
- allow one-click download of all course resources

## Testing
- `php -l local/downloadcenter/course_select_form.php`
- `php -l local/downloadcenter/lang/en/local_downloadcenter.php`
- `php -l local/downloadcenter/index.php`
- `vendor/bin/phpunit local/downloadcenter/tests/files_visible_test.php` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a6c5fb580832aa059cb4ba94006cd