### PR TITLE
feat: add username generation tool

### DIFF
--- a/admin/tool/generateusername/db/access.php
+++ b/admin/tool/generateusername/db/access.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Capability definitions for tool_generateusername.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [
+    'tool/generateusername:generateusername' => [
+        'riskbitmask' => RISK_PERSONAL,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW
+        ],
+    ],
+];
+

--- a/admin/tool/generateusername/index.php
+++ b/admin/tool/generateusername/index.php
@@ -1,0 +1,191 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Generate usernames from CSV data.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require('../../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/csvlib.class.php');
+require_once($CFG->libdir . '/excellib.class.php');
+require_once($CFG->dirroot . '/user/lib.php');
+require_once($CFG->dirroot . '/user/profile/lib.php');
+require_once($CFG->dirroot . '/lib/moodlelib.php');
+require_once($CFG->dirroot . '/admin/tool/uploaduser/locallib.php');
+require_once(__DIR__ . '/locallib.php');
+require_once(__DIR__ . '/user_form.php');
+
+require_login();
+admin_externalpage_setup('toolgenerateusername');
+require_capability('tool/generateusername:generateusername', context_system::instance());
+
+$download = optional_param('download', '', PARAM_ALPHA);
+
+if ($download) {
+    $content = $SESSION->tool_generateusername_export ?? null;
+    if ($content) {
+        $filename = 'generated_users';
+        if ($download === 'xlsx') {
+            $workbook = new MoodleExcelWorkbook('-');
+            $workbook->send($filename . '.xlsx');
+            $sheet = $workbook->add_worksheet('users');
+            foreach ($content as $r => $row) {
+                $c = 0;
+                foreach ($row as $value) {
+                    $sheet->write_string($r, $c++, $value);
+                }
+            }
+            $workbook->close();
+        } else {
+            $export = new csv_export_writer('semicolon');
+            $export->set_filename($filename);
+            foreach ($content as $row) {
+                $export->add_data($row);
+            }
+            $export->download_file();
+        }
+    }
+    die();
+}
+
+$form = new tool_generateusername_form();
+
+if ($data = $form->get_data()) {
+    $iid = csv_import_reader::get_new_iid('toolgenerateusername');
+    $content = $form->get_file_content('userfile');
+    $cir = new csv_import_reader($iid, 'toolgenerateusername');
+    $cir->load_csv_content($content, $data->encoding, $data->delimiter_name);
+
+    $returnurl = new moodle_url('/admin/tool/generateusername/index.php');
+
+    // Valid columns as in tool_uploaduser.
+    $STD_FIELDS = ['id', 'username', 'email', 'city', 'country', 'lang', 'timezone',
+        'mailformat', 'maildisplay', 'maildigest', 'htmleditor', 'autosubscribe',
+        'institution', 'department', 'idnumber', 'skype', 'msn', 'aim', 'yahoo', 'icq',
+        'phone1', 'phone2', 'address', 'url', 'description', 'descriptionformat',
+        'password', 'auth', 'oldusername', 'suspended', 'deleted', 'mnethostid'];
+    $STD_FIELDS = array_merge($STD_FIELDS, get_all_user_name_fields());
+
+    $PRF_FIELDS = [];
+    if ($proffields = $DB->get_records('user_info_field')) {
+        foreach ($proffields as $key => $proffield) {
+            $profilefieldname = 'profile_field_' . $proffield->shortname;
+            $PRF_FIELDS[] = $profilefieldname;
+            $proffields[$profilefieldname] = $proffield;
+            unset($proffields[$key]);
+        }
+    }
+
+    $filecolumns = uu_validate_user_upload_columns($cir, $STD_FIELDS, $PRF_FIELDS, $returnurl);
+    if (in_array('username', $filecolumns)) {
+        print_error('usernamepresent', 'tool_generateusername');
+    }
+
+    $required = ['firstname', 'lastname', 'email', 'idnumber', 'password'];
+    if ($missing = array_diff($required, $filecolumns)) {
+        print_error('missingrequiredfields', 'tool_generateusername');
+    }
+
+    // Determine columns to output: username, firstname, lastname, email, idnumber, password, profile fields, others.
+    $profilecolumns = [];
+    foreach ($filecolumns as $column) {
+        if (strpos($column, 'profile_field_') === 0) {
+            $profilecolumns[] = $column;
+        }
+    }
+    $othercolumns = array_diff($filecolumns, $required);
+    $othercolumns = array_diff($othercolumns, $profilecolumns);
+    $basecolumns = ['firstname', 'lastname', 'email', 'idnumber', 'password'];
+    $exportcolumns = array_merge(['username'], $basecolumns, $profilecolumns, $othercolumns);
+    $exportdata = [$exportcolumns];
+
+    $cir->init();
+    $existing = [];
+    while ($line = $cir->next()) {
+        $record = array_combine($filecolumns, $line);
+        $idnumber = trim($record['idnumber']);
+        $email = trim($record['email']);
+
+        if ($existinguser = $DB->get_record('user', ['idnumber' => $idnumber, 'email' => $email])) {
+            $username = $existinguser->username;
+            $firstname = $existinguser->firstname;
+            $lastname = $existinguser->lastname;
+            $email = $existinguser->email;
+            $profiledata = profile_user_record($existinguser->id, false);
+        } else {
+            $firstname = $record['firstname'];
+            $lastname = $record['lastname'];
+            $email = $record['email'];
+            $base = tool_generateusername_generate_username($firstname, $lastname);
+            $username = tool_generateusername_make_unique($base, $existing);
+            $profiledata = null;
+        }
+        $existing[] = $username;
+
+        $output = [
+            'username' => $username,
+            'firstname' => $firstname,
+            'lastname' => $lastname,
+            'email' => $email,
+            'idnumber' => $idnumber,
+            'password' => $record['password'] ?? ''
+        ];
+
+        foreach ($profilecolumns as $column) {
+            if ($profiledata && property_exists($profiledata, $column)) {
+                $output[$column] = $profiledata->$column;
+            } else {
+                $output[$column] = $record[$column] ?? '';
+            }
+        }
+        foreach ($othercolumns as $column) {
+            if ($column === 'suspended') {
+                $output[$column] = $record[$column] ?? '0';
+            } else {
+                $output[$column] = $record[$column] ?? '';
+            }
+        }
+        $row = [];
+        foreach ($exportcolumns as $column) {
+            $row[] = $output[$column] ?? '';
+        }
+        $exportdata[] = $row;
+    }
+    $cir->close();
+
+    $SESSION->tool_generateusername_export = $exportdata;
+
+    echo $OUTPUT->header();
+    echo $OUTPUT->heading(get_string('pluginname', 'tool_generateusername'));
+    $urlcsv = new moodle_url('/admin/tool/generateusername/index.php', ['download' => 'csv']);
+    $urlexcel = new moodle_url('/admin/tool/generateusername/index.php', ['download' => 'xlsx']);
+    echo html_writer::div(html_writer::link($urlexcel, get_string('downloadexcel', 'tool_generateusername')));
+    echo html_writer::div(html_writer::link($urlcsv, get_string('downloadcsv', 'tool_generateusername')));
+    echo $OUTPUT->footer();
+    die();
+}
+
+// Show upload form.
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('pluginname', 'tool_generateusername'));
+$form->display();
+echo $OUTPUT->footer();
+

--- a/admin/tool/generateusername/lang/en/tool_generateusername.php
+++ b/admin/tool/generateusername/lang/en/tool_generateusername.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language strings for tool_generateusername.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['pluginname'] = 'Generate usernames';
+$string['generate'] = 'Generate usernames';
+$string['downloadcsv'] = 'Download CSV';
+$string['downloadexcel'] = 'Download Excel';
+$string['missingrequiredfields'] = 'Required fields firstname, lastname, email, idnumber and password were not found.';
+$string['usernamepresent'] = 'The uploaded file already contains a username column.';
+$string['privacy:metadata'] = 'The Generate usernames plugin does not store personal data.';
+

--- a/admin/tool/generateusername/lang/es/tool_generateusername.php
+++ b/admin/tool/generateusername/lang/es/tool_generateusername.php
@@ -1,0 +1,34 @@
+<?php
+// Este archivo forma parte de Moodle - http://moodle.org/
+//
+// Moodle es software libre: puede redistribuirlo y/o modificarlo
+// bajo los términos de la Licencia Pública General GNU publicada por
+// la Free Software Foundation, ya sea la versión 3 de la licencia, o
+// (a su elección) cualquier versión posterior.
+//
+// Moodle se distribuye con la esperanza de que sea útil,
+// pero SIN NINGUNA GARANTÍA; sin incluso la garantía implícita de
+// COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Vea la
+// Licencia Pública General GNU para más detalles.
+//
+// Debería haber recibido una copia de la Licencia Pública General GNU
+// junto con Moodle. Si no, vea <http://www.gnu.org/licenses/>.
+
+/**
+ * Cadenas de idioma para tool_generateusername.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 o posterior
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['pluginname'] = 'Generar nombres de usuario';
+$string['generate'] = 'Generar nombres de usuario';
+$string['downloadcsv'] = 'Descargar CSV';
+$string['downloadexcel'] = 'Descargar Excel';
+$string['missingrequiredfields'] = 'No se encontraron los campos requeridos firstname, lastname, email, idnumber y password.';
+$string['usernamepresent'] = 'El archivo subido ya contiene una columna username.';
+$string['privacy:metadata'] = 'El plugin Generar nombres de usuario no almacena datos personales.';
+

--- a/admin/tool/generateusername/locallib.php
+++ b/admin/tool/generateusername/locallib.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Helper functions for username generation.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Clean text by removing accents and special characters.
+ *
+ * @param string $text
+ * @return string
+ */
+function tool_generateusername_clean_text($text) {
+    $text = moodle_strtolower(core_text::remove_accents(trim($text)));
+    $text = preg_replace('/[^a-z]/', '', $text);
+    return $text;
+}
+
+/**
+ * Generate username from firstname and lastname.
+ *
+ * Policy:
+ * - first 4 letters of firstname
+ * - first 3 letters of first surname
+ * - first letter of second surname
+ * Missing parts are padded with x.
+ *
+ * @param string $firstname
+ * @param string $lastname
+ * @return string
+ */
+function tool_generateusername_generate_username($firstname, $lastname) {
+    $firstname = tool_generateusername_clean_text($firstname);
+    $lastname = tool_generateusername_clean_text($lastname);
+    $lastnameparts = preg_split('/\s+/', $lastname);
+    $firstsurname = $lastnameparts[0] ?? '';
+    $secondsurname = $lastnameparts[1] ?? '';
+
+    $namepart = substr(str_replace(' ', '', $firstname), 0, 4);
+    $namepart = str_pad($namepart, 4, 'x');
+    $firstpart = str_pad(substr($firstsurname, 0, 3), 3, 'x');
+    $secondpart = $secondsurname !== '' ? substr($secondsurname, 0, 1) : 'x';
+    return $namepart . $firstpart . $secondpart;
+}
+
+/**
+ * Make username unique against existing array and database.
+ *
+ * @param string $base
+ * @param array $existing
+ * @return string
+ */
+function tool_generateusername_make_unique($base, array $existing) {
+    global $DB;
+    $username = $base;
+    $suffix = 1;
+    while (in_array($username, $existing) || $DB->record_exists('user', ['username' => $username])) {
+        $username = substr($base, 0, 7) . $suffix;
+        $suffix++;
+    }
+    return $username;
+}
+

--- a/admin/tool/generateusername/settings.php
+++ b/admin/tool/generateusername/settings.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Settings for username generation tool.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+if ($hassiteconfig) {
+    $ADMIN->add('accounts', new admin_externalpage('toolgenerateusername',
+        get_string('pluginname', 'tool_generateusername'),
+        new moodle_url('/admin/tool/generateusername/index.php'),
+        'tool/generateusername:generateusername'));
+}
+

--- a/admin/tool/generateusername/user_form.php
+++ b/admin/tool/generateusername/user_form.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Form for uploading CSV without usernames.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir.'/formslib.php');
+
+/**
+ * Upload a CSV file with user information missing usernames.
+ */
+class tool_generateusername_form extends moodleform {
+    public function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('header', 'settingsheader', get_string('upload')); // Generic upload header.
+
+        $mform->addElement('filepicker', 'userfile', get_string('file'), null, ['accepted_types' => '.csv']);
+        $mform->addRule('userfile', null, 'required');
+
+        $choices = csv_import_reader::get_delimiter_list();
+        $mform->addElement('select', 'delimiter_name', get_string('csvdelimiter', 'tool_uploaduser'), $choices);
+        if (array_key_exists('cfg', $choices)) {
+            $mform->setDefault('delimiter_name', 'cfg');
+        } else if (get_string('listsep', 'langconfig') == ';') {
+            $mform->setDefault('delimiter_name', 'semicolon');
+        } else {
+            $mform->setDefault('delimiter_name', 'comma');
+        }
+
+        $encodings = core_text::get_encodings();
+        $mform->addElement('select', 'encoding', get_string('encoding', 'tool_uploaduser'), $encodings);
+        $mform->setDefault('encoding', 'UTF-8');
+
+        $this->add_action_buttons(false, get_string('generate', 'tool_generateusername'));
+    }
+}
+

--- a/admin/tool/generateusername/version.php
+++ b/admin/tool/generateusername/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version information for tool_generateusername.
+ *
+ * @package   tool_generateusername
+ * @copyright 2024 Alonso Arias
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version   = 2024112600; // YYYYMMDDHH (approx).
+$plugin->requires  = 2022041900; // Moodle 4.0.
+$plugin->component = 'tool_generateusername';
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->release   = '0.1';
+


### PR DESCRIPTION
## Summary
- add `tool_generateusername` admin plugin to build usernames from CSV files
- validate upload columns like `uploaduser` while forbidding `username`
- allow CSV or Excel download with generated usernames and profile fields

## Testing
- `php -l admin/tool/generateusername/index.php`
- `php -l admin/tool/generateusername/version.php`
- `php -l admin/tool/generateusername/lang/en/tool_generateusername.php`
- `php -l admin/tool/generateusername/lang/es/tool_generateusername.php`
- `php -l admin/tool/generateusername/locallib.php`
- `php -l admin/tool/generateusername/user_form.php`
- `php -l admin/tool/generateusername/settings.php`
- `php -l admin/tool/generateusername/db/access.php`


------
https://chatgpt.com/codex/tasks/task_e_689a6a99264c832ab099d725a1be0715