### PR TITLE
feat: add risky question handling and review panel

### DIFF
--- a/local/quiz_retake_ui/README.md
+++ b/local/quiz_retake_ui/README.md
@@ -1,0 +1,14 @@
+# Quiz Retake UI
+
+Plugin extending quiz attempts with "risk" checkboxes, dual-grade calculation and review page with visual summary,
+filters and retake options.
+
+## Installation
+
+1. Copy the plugin to `local/quiz_retake_ui`.
+2. Visit the site administration to trigger the installation.
+
+## Notes
+
+Risky selections are stored per attempt and excluded from the risk-free grade. The retake endpoint is a stub and must be
+extended to build a new attempt using the Moodle question engine.

--- a/local/quiz_retake_ui/amd/src/attempt.js
+++ b/local/quiz_retake_ui/amd/src/attempt.js
@@ -1,0 +1,26 @@
+// AMD module to handle risky checkbox during quiz attempt.
+import Ajax from 'core/ajax';
+import Notification from 'core/notification';
+
+export const init = (attemptid) => {
+    document.querySelectorAll('.que').forEach(q => {
+        const slot = q.dataset.slot;
+        if (!slot) {
+            return;
+        }
+        const container = q.querySelector('.formulation');
+        if (!container) {
+            return;
+        }
+        const label = document.createElement('label');
+        label.classList.add('ml-2');
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.classList.add('quiz-retake-risky');
+        checkbox.addEventListener('change', e => {
+            Ajax.call([{methodname: 'local_quiz_retake_ui_toggle_risky', args: {attemptid: attemptid, slot: slot, state: e.target.checked}, fail: Notification.exception}]);
+        });
+        label.append(checkbox, ' ', M.util.get_string('markrisky', 'local_quiz_retake_ui'));
+        container.appendChild(label);
+    });
+};

--- a/local/quiz_retake_ui/amd/src/review.js
+++ b/local/quiz_retake_ui/amd/src/review.js
@@ -1,0 +1,42 @@
+// AMD module for quiz retake review page.
+import Ajax from 'core/ajax';
+import Notification from 'core/notification';
+import Templates from 'core/templates';
+
+export const init = (attemptid) => {
+    Ajax.call([{
+        methodname: 'local_quiz_retake_ui_get_attempt_stats',
+        args: {attemptid: attemptid},
+        done: data => {
+            Templates.render('local_quiz_retake_ui/review_panel', data).then(html => {
+                const container = document.querySelector('#region-main');
+                container.insertAdjacentHTML('afterbegin', html);
+                const root = container.querySelector('.quiz-retake-summary');
+                if (data.riskyslots) {
+                    data.riskyslots.forEach(slot => {
+                        const q = document.querySelector('.que[data-slot="' + slot + '"]');
+                        if (q) {
+                            q.classList.add('risky');
+                        }
+                    });
+                }
+                const filters = root.querySelectorAll('[data-filter]');
+                filters.forEach(btn => {
+                    btn.addEventListener('click', e => {
+                        const filter = e.currentTarget.dataset.filter;
+                        document.querySelectorAll('.que').forEach(q => {
+                            q.style.display = (filter === 'all' || q.classList.contains(filter)) ? '' : 'none';
+                        });
+                    });
+                });
+                const retakebtn = root.querySelector('[data-action="retake"]');
+                if (retakebtn) {
+                    retakebtn.addEventListener('click', () => {
+                        Ajax.call([{methodname: 'local_quiz_retake_ui_create_retake', args: {attemptid: attemptid, mode: 'failed'}, done: data => {window.location = M.cfg.wwwroot + '/mod/quiz/attempt.php?attempt=' + data.newattemptid;}, fail: Notification.exception}]);
+                    });
+                }
+            }).catch(Notification.exception);
+        },
+        fail: Notification.exception
+    }]);
+};

--- a/local/quiz_retake_ui/classes/external/create_retake.php
+++ b/local/quiz_retake_ui/classes/external/create_retake.php
@@ -1,0 +1,39 @@
+<?php
+namespace local_quiz_retake_ui\external;
+
+use external_api;
+use external_function_parameters;
+use external_value;
+use context_module;
+use mod_quiz\quiz_attempt;
+use moodle_url;
+use question_engine;
+use question_usage_by_activity;
+
+class create_retake extends external_api {
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'attemptid' => new external_value(PARAM_INT, 'Original attempt id'),
+            'mode' => new external_value(PARAM_ALPHA, 'subset option'),
+        ]);
+    }
+
+    public static function execute(int $attemptid, string $mode): array {
+        $attemptobj = quiz_attempt::create($attemptid);
+        require_login($attemptobj->get_course(), false, $attemptobj->get_cm());
+        $context = context_module::instance($attemptobj->get_cmid());
+        self::validate_context($context);
+        require_sesskey();
+
+        // TODO: Build new attempt based on $mode.
+        $newattemptid = 0;
+
+        return ['newattemptid' => $newattemptid];
+    }
+
+    public static function execute_returns() {
+        return new external_function_parameters([
+            'newattemptid' => new external_value(PARAM_INT, 'ID of the created attempt'),
+        ]);
+    }
+}

--- a/local/quiz_retake_ui/classes/external/get_attempt_stats.php
+++ b/local/quiz_retake_ui/classes/external/get_attempt_stats.php
@@ -1,0 +1,76 @@
+<?php
+// External function to return attempt statistics.
+
+namespace local_quiz_retake_ui\external;
+
+use external_api;
+use external_function_parameters;
+use external_single_structure;
+use external_multiple_structure;
+use external_value;
+use context_module;
+use mod_quiz\quiz_attempt;
+use moodle_exception;
+
+class get_attempt_stats extends external_api {
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'attemptid' => new external_value(PARAM_INT, 'Attempt ID'),
+        ]);
+    }
+
+    public static function execute(int $attemptid): array {
+        global $PAGE;
+        $attemptobj = quiz_attempt::create($attemptid);
+        require_login($attemptobj->get_course(), false, $attemptobj->get_cm());
+        $context = context_module::instance($attemptobj->get_cmid());
+        self::validate_context($context);
+
+        global $DB, $USER;
+        $riskys = $DB->get_records('local_quiz_retake_risky', ['attemptid' => $attemptid, 'userid' => $USER->id], '', 'slot');
+        $riskyslots = array_map(fn($r) => $r->slot, $riskys);
+        $correct = $incorrect = $blank = 0;
+        foreach ($attemptobj->get_slots() as $slot) {
+            $qa = $attemptobj->get_question_attempt($slot);
+            if ($qa->get_state()->is_unanswered()) {
+                $blank++;
+                continue;
+            }
+            if ($qa->get_fraction() >= 1) {
+                $correct++;
+            } else {
+                $incorrect++;
+            }
+        }
+        $normalgrade = quiz_rescale_grade($attemptobj->get_sum_marks(), $attemptobj->get_quiz(), false);
+        $riskfreegrade = quiz_rescale_grade(grades::risk_free_grade($attemptobj, $riskyslots), $attemptobj->get_quiz(), false);
+        $resultpass = $normalgrade >= $attemptobj->get_quiz()->gradepass;
+        return [
+            'normalgrade' => $normalgrade,
+            'riskfreegrade' => $riskfreegrade,
+            'correct' => $correct,
+            'incorrect' => $incorrect,
+            'blank' => $blank,
+            'risky' => count($riskyslots),
+            'riskyslots' => $riskyslots,
+            'cutgrade' => $attemptobj->get_quiz()->gradepass,
+            'result' => $resultpass ? get_string('pass', 'local_quiz_retake_ui') : get_string('fail', 'local_quiz_retake_ui'),
+            'pass' => $resultpass,
+        ];
+    }
+
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure([
+            'normalgrade' => new external_value(PARAM_FLOAT, 'Normal grade'),
+            'riskfreegrade' => new external_value(PARAM_FLOAT, 'Risk-free grade'),
+            'correct' => new external_value(PARAM_INT, 'Correct questions'),
+            'incorrect' => new external_value(PARAM_INT, 'Incorrect questions'),
+            'blank' => new external_value(PARAM_INT, 'Unanswered questions'),
+            'risky' => new external_value(PARAM_INT, 'Risked questions'),
+            'cutgrade' => new external_value(PARAM_FLOAT, 'Grade to pass'),
+            'result' => new external_value(PARAM_TEXT, 'Result string'),
+            'pass' => new external_value(PARAM_BOOL, 'Whether passed'),
+            'riskyslots' => new external_multiple_structure(new external_value(PARAM_INT, 'Risky slot')),
+        ]);
+    }
+}

--- a/local/quiz_retake_ui/classes/external/toggle_risky.php
+++ b/local/quiz_retake_ui/classes/external/toggle_risky.php
@@ -1,0 +1,51 @@
+<?php
+namespace local_quiz_retake_ui\external;
+
+use external_api;
+use external_function_parameters;
+use external_value;
+use context_module;
+use mod_quiz\quiz_attempt;
+use dml_exception;
+
+class toggle_risky extends external_api {
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'attemptid' => new external_value(PARAM_INT, 'Attempt ID'),
+            'slot' => new external_value(PARAM_INT, 'Question slot'),
+            'state' => new external_value(PARAM_BOOL, 'Whether question is risky'),
+        ]);
+    }
+
+    /**
+     * Mark or unmark a question as risky for an attempt.
+     * @throws \required_capability_exception|\moodle_exception
+     */
+    public static function execute(int $attemptid, int $slot, bool $state): array {
+        global $DB, $USER;
+
+        $attemptobj = quiz_attempt::create($attemptid);
+        require_login($attemptobj->get_course(), false, $attemptobj->get_cm());
+        $context = context_module::instance($attemptobj->get_cmid());
+        self::validate_context($context);
+        require_capability('mod/quiz:attempt', $context);
+        require_sesskey();
+
+        $params = ['attemptid' => $attemptid, 'slot' => $slot, 'userid' => $USER->id];
+        if ($state) {
+            if (!$DB->record_exists('local_quiz_retake_risky', $params)) {
+                $params['timecreated'] = time();
+                $DB->insert_record('local_quiz_retake_risky', $params);
+            }
+        } else {
+            $DB->delete_records('local_quiz_retake_risky', $params);
+        }
+        return ['status' => 'ok'];
+    }
+
+    public static function execute_returns() {
+        return new external_function_parameters([
+            'status' => new external_value(PARAM_TEXT, 'Result status'),
+        ]);
+    }
+}

--- a/local/quiz_retake_ui/classes/grades.php
+++ b/local/quiz_retake_ui/classes/grades.php
@@ -1,0 +1,22 @@
+<?php
+namespace local_quiz_retake_ui;
+
+use mod_quiz\quiz_attempt;
+
+class grades {
+    /**
+     * Calculate risk-free grade excluding risky slots.
+     * This is a simplified placeholder.
+     */
+    public static function risk_free_grade(quiz_attempt $attempt, array $riskyslots): float {
+        // Placeholder: simply return attempt's sumgrades ignoring risky slots.
+        $grade = 0;
+        foreach ($attempt->get_slots() as $slot) {
+            if (in_array($slot, $riskyslots)) {
+                continue;
+            }
+            $grade += $attempt->get_question_attempt($slot)->get_mark();
+        }
+        return $grade;
+    }
+}

--- a/local/quiz_retake_ui/classes/observer.php
+++ b/local/quiz_retake_ui/classes/observer.php
@@ -1,0 +1,10 @@
+<?php
+namespace local_quiz_retake_ui;
+
+use mod_quiz\event\attempt_reviewed;
+
+class observer {
+    public static function attempt_reviewed(attempt_reviewed $event): void {
+        // Placeholder for logging or other actions.
+    }
+}

--- a/local/quiz_retake_ui/classes/review_panel.php
+++ b/local/quiz_retake_ui/classes/review_panel.php
@@ -1,0 +1,23 @@
+<?php
+namespace local_quiz_retake_ui;
+
+use renderable;
+use templatable;
+use renderer_base;
+use stdClass;
+
+class review_panel implements renderable, templatable {
+    public function __construct(
+        public array $stats,
+        public string $cutgrade,
+        public string $result
+    ) {}
+
+    public function export_for_template(renderer_base $output): stdClass {
+        return (object) [
+            'stats' => $this->stats,
+            'cutgrade' => $this->cutgrade,
+            'result' => $this->result,
+        ];
+    }
+}

--- a/local/quiz_retake_ui/db/events.php
+++ b/local/quiz_retake_ui/db/events.php
@@ -1,0 +1,8 @@
+<?php
+$observers = [
+    [
+        'eventname'   => '\\mod_quiz\\event\\attempt_reviewed',
+        'callback'    => 'local_quiz_retake_ui\\observer::attempt_reviewed',
+        'priority'    => 9999,
+    ],
+];

--- a/local/quiz_retake_ui/db/install.xml
+++ b/local/quiz_retake_ui/db/install.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<XMLDB PATH="local/quiz_retake_ui/db" VERSION="20241015" COMMENT="Install XML for quiz retake UI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <TABLES>
+        <TABLE NAME="local_quiz_retake_log" COMMENT="Links original attempts with generated retakes">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+                <FIELD NAME="originalattemptid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+                <FIELD NAME="newattemptid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+                <FIELD NAME="questionids" TYPE="text" NOTNULL="false"/>
+                <FIELD NAME="options" TYPE="text" NOTNULL="false"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_quiz_retake_risky" COMMENT="Questions flagged as risky by the user">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="attemptid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+                <FIELD NAME="slot" TYPE="int" LENGTH="10" NOTNULL="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+    </TABLES>
+</XMLDB>

--- a/local/quiz_retake_ui/db/services.php
+++ b/local/quiz_retake_ui/db/services.php
@@ -1,0 +1,30 @@
+<?php
+$functions = [
+    'local_quiz_retake_ui_get_attempt_stats' => [
+        'classname'   => 'local_quiz_retake_ui\external\get_attempt_stats',
+        'methodname'  => 'execute',
+        'classpath'   => '',
+        'description' => 'Return counts and grades for an attempt',
+        'type'        => 'read',
+        'ajax'        => true,
+        'services'    => [MOODLE_OFFICIAL_MOBILE_SERVICE]
+    ],
+    'local_quiz_retake_ui_create_retake' => [
+        'classname'   => 'local_quiz_retake_ui\external\create_retake',
+        'methodname'  => 'execute',
+        'classpath'   => '',
+        'description' => 'Create a retake attempt with selected questions',
+        'type'        => 'write',
+        'ajax'        => true,
+        'services'    => [MOODLE_OFFICIAL_MOBILE_SERVICE]
+    ],
+    'local_quiz_retake_ui_toggle_risky' => [
+        'classname'   => 'local_quiz_retake_ui\external\toggle_risky',
+        'methodname'  => 'execute',
+        'classpath'   => '',
+        'description' => 'Toggle risky flag for a question slot',
+        'type'        => 'write',
+        'ajax'        => true,
+        'services'    => [MOODLE_OFFICIAL_MOBILE_SERVICE]
+    ],
+];

--- a/local/quiz_retake_ui/lang/en/local_quiz_retake_ui.php
+++ b/local/quiz_retake_ui/lang/en/local_quiz_retake_ui.php
@@ -1,0 +1,19 @@
+<?php
+// Language strings for quiz_retake_ui plugin.
+
+$string['pluginname'] = 'Quiz retake UI';
+$string['retakequiz'] = 'Retake quiz';
+$string['filterall'] = 'All';
+$string['filtercorrect'] = 'Correct';
+$string['filterincorrect'] = 'Incorrect';
+$string['filterblank'] = 'Unanswered';
+$string['filterrisky'] = 'Risked';
+$string['normalgrade'] = 'Normal grade';
+$string['riskfreegrade'] = 'Risk-free grade';
+$string['markrisky'] = 'Risk';
+$string['pass'] = 'Pass';
+$string['fail'] = 'Fail';
+$string['repeatfailed'] = 'Repeat failed questions';
+$string['repeatfailedblank'] = 'Repeat failed and blank questions';
+$string['repeatfailedrisky'] = 'Repeat failed and risky questions';
+$string['repeatfailedblankrisky'] = 'Repeat failed, blank and risky questions';

--- a/local/quiz_retake_ui/lib.php
+++ b/local/quiz_retake_ui/lib.php
@@ -1,0 +1,20 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Inject JS and CSS on quiz review pages.
+ */
+function local_quiz_retake_ui_before_http_headers() {
+    global $PAGE, $CFG;
+    if (!$PAGE->has_set_url()) {
+        return;
+    }
+    $url = $PAGE->url->out_as_local_url();
+    if (strpos($url, '/mod/quiz/review.php') === 0) {
+        $PAGE->requires->js_call_amd('local_quiz_retake_ui/review', 'init', [optional_param('attempt', 0, PARAM_INT)]);
+        $PAGE->requires->css('/local/quiz_retake_ui/styles/styles.css');
+    } else if (strpos($url, '/mod/quiz/attempt.php') === 0) {
+        $PAGE->requires->js_call_amd('local_quiz_retake_ui/attempt', 'init', [optional_param('attempt', 0, PARAM_INT)]);
+        $PAGE->requires->css('/local/quiz_retake_ui/styles/styles.css');
+    }
+}

--- a/local/quiz_retake_ui/styles/styles.css
+++ b/local/quiz_retake_ui/styles/styles.css
@@ -1,0 +1,3 @@
+/* Compiled CSS placeholder for quiz retake UI */
+.quiz-retake-summary .quiz-retake-filters .btn{border-radius:2rem;}
+.quiz-retake-summary .quiz-retake-stats div{padding:.25rem .5rem;}

--- a/local/quiz_retake_ui/styles/styles.scss
+++ b/local/quiz_retake_ui/styles/styles.scss
@@ -1,0 +1,8 @@
+.quiz-retake-summary {
+    .quiz-retake-stats div {
+        padding: .25rem .5rem;
+    }
+    .quiz-retake-filters .btn {
+        border-radius: 2rem;
+    }
+}

--- a/local/quiz_retake_ui/templates/review_panel.mustache
+++ b/local/quiz_retake_ui/templates/review_panel.mustache
@@ -1,0 +1,33 @@
+{{! Template for attempt review panel }}
+<div class="quiz-retake-summary card p-3">
+    <div class="row mb-3">
+        <div class="col-md-4 text-center">
+            <div class="display-4 text-primary">{{normalgrade}}</div>
+            <div>{{#str}}normalgrade, local_quiz_retake_ui{{/str}}</div>
+        </div>
+        <div class="col-md-4 text-center">
+            <div class="h3 text-secondary">{{cutgrade}}</div>
+            <div>{{#str}}gradepass, quiz{{/str}}</div>
+        </div>
+        <div class="col-md-4 text-center">
+            <span class="badge {{#pass}}bg-success{{/pass}}{{^pass}}bg-danger{{/pass}}">{{result}}</span>
+        </div>
+    </div>
+    <div class="d-flex justify-content-around mb-3 quiz-retake-stats">
+        <div class="text-warning">{{#str}}riskfreegrade, local_quiz_retake_ui{{/str}}: {{riskfreegrade}}</div>
+        <div class="text-success">{{#str}}filtercorrect, local_quiz_retake_ui{{/str}}: {{correct}}</div>
+        <div class="text-danger">{{#str}}filterincorrect, local_quiz_retake_ui{{/str}}: {{incorrect}}</div>
+        <div class="text-primary">{{#str}}filterblank, local_quiz_retake_ui{{/str}}: {{blank}}</div>
+        <div class="text-warning">{{#str}}filterrisky, local_quiz_retake_ui{{/str}}: {{risky}}</div>
+    </div>
+    <div class="quiz-retake-filters btn-group" role="group">
+        <button type="button" class="btn btn-secondary" data-filter="all">{{#str}}filterall, local_quiz_retake_ui{{/str}}</button>
+        <button type="button" class="btn btn-secondary" data-filter="correct">{{#str}}filtercorrect, local_quiz_retake_ui{{/str}}</button>
+        <button type="button" class="btn btn-secondary" data-filter="incorrect">{{#str}}filterincorrect, local_quiz_retake_ui{{/str}}</button>
+        <button type="button" class="btn btn-secondary" data-filter="blank">{{#str}}filterblank, local_quiz_retake_ui{{/str}}</button>
+        <button type="button" class="btn btn-secondary" data-filter="risky">{{#str}}filterrisky, local_quiz_retake_ui{{/str}}</button>
+    </div>
+    <div class="mt-3 text-end">
+        <button type="button" class="btn btn-primary" data-action="retake">{{#str}}retakequiz, local_quiz_retake_ui{{/str}}</button>
+    </div>
+</div>

--- a/local/quiz_retake_ui/tests/grades_test.php
+++ b/local/quiz_retake_ui/tests/grades_test.php
@@ -1,0 +1,27 @@
+<?php
+// PHPUnit tests for grades class.
+namespace local_quiz_retake_ui\tests;
+
+use advanced_testcase;
+use local_quiz_retake_ui\grades;
+use mod_quiz\quiz_attempt;
+
+class grades_test extends advanced_testcase {
+    public function test_risk_free_grade(): void {
+        $this->resetAfterTest();
+        $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $quizgenerator->create_instance(['course' => $course->id, 'sumgrades' => 10]);
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $question = $questiongenerator->create_question('truefalse', null, ['name' => 'Q1']);
+        quiz_add_quiz_question($question->id, $quiz, 0);
+
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+        $attemptobj = $quizgenerator->create_attempt($quiz, $user);
+
+        $attempt = quiz_attempt::create($attemptobj->id);
+        $grade = grades::risk_free_grade($attempt, []);
+        $this->assertEquals(0, $grade, 'No marks awarded initially');
+    }
+}

--- a/local/quiz_retake_ui/version.php
+++ b/local/quiz_retake_ui/version.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version information for quiz_retake_ui plugin.
+ *
+ * @package    local_quiz_retake_ui
+ * @copyright  2024 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'local_quiz_retake_ui';
+$plugin->version   = 2024101500;
+$plugin->requires  = 2024100100; // Moodle 4.5 minimum.
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->release   = '0.1-dev';


### PR DESCRIPTION
## Summary
- allow marking questions as risky during attempts
- render review panel with dual grades and filtering
- expose web services for stats, retake and toggling risky flags

## Testing
- `vendor/bin/phpunit local/quiz_retake_ui/tests/grades_test.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e9aea0f0832a81b235b285b0d214