### PR TITLE
feat: add hierarchical category selection

### DIFF
--- a/local/downloadcenter/amd/src/category_tree.js
+++ b/local/downloadcenter/amd/src/category_tree.js
@@ -1,0 +1,58 @@
+/**
+ * Manage tri-state category checkboxes on the download center page.
+ *
+ * @module     local_downloadcenter/category_tree
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+define(['jquery'], function($) {
+    'use strict';
+
+    function updateCategoryState($checkbox) {
+        var $container = $checkbox.closest('.downloadcenter-category');
+        var $courseboxes = $container.find('.course-checkbox');
+        var $subcatboxes = $container.find('> .collapse .card-body .downloadcenter-category-checkbox');
+        var total = $courseboxes.length + $subcatboxes.length;
+        var checked = $courseboxes.filter(':checked').length + $subcatboxes.filter(':checked').length;
+        var indeterminateChildren = $subcatboxes.filter(function() { return this.indeterminate; }).length;
+        $checkbox.prop('checked', total > 0 && checked === total);
+        $checkbox.prop('indeterminate', (checked > 0 && checked < total) || indeterminateChildren > 0);
+    }
+
+    function propagateToChildren($checkbox, checked) {
+        var $container = $checkbox.closest('.downloadcenter-category');
+        $container.find('.course-checkbox, .downloadcenter-category-checkbox').each(function() {
+            this.checked = checked;
+            this.indeterminate = false;
+            $(this).trigger('change');
+        });
+    }
+
+    return {
+        init: function() {
+            $('.downloadcenter-category').each(function() {
+                var $cat = $(this);
+                var $catbox = $cat.find('> .card-header input.downloadcenter-category-checkbox');
+                if ($catbox.data('indeterminate')) {
+                    $catbox.prop('indeterminate', true);
+                }
+                $catbox.on('change', function() {
+                    propagateToChildren($catbox, $catbox.is(':checked'));
+                    var $current = $catbox.closest('.downloadcenter-category').parents('.downloadcenter-category').first();
+                    while ($current.length) {
+                        var $parentbox = $current.find('> .card-header input.downloadcenter-category-checkbox');
+                        updateCategoryState($parentbox);
+                        $current = $current.parents('.downloadcenter-category').first();
+                    }
+                });
+                $cat.find('.course-checkbox').on('change', function() {
+                    var $current = $(this).closest('.downloadcenter-category');
+                    while ($current.length) {
+                        var $parentbox = $current.find('> .card-header input.downloadcenter-category-checkbox');
+                        updateCategoryState($parentbox);
+                        $current = $current.parents('.downloadcenter-category').first();
+                    }
+                });
+            });
+        }
+    };
+});

--- a/local/downloadcenter/course_select_form.php
+++ b/local/downloadcenter/course_select_form.php
@@ -39,8 +39,15 @@ class local_downloadcenter_course_select_form extends moodleform {
             if (isset($selection[$course->id])) {
                 $label .= ' (' . get_string('selected', 'local_downloadcenter') . ')';
             }
-            $mform->addElement('advcheckbox', 'courses[' . $course->id . ']', '', $label, ['group' => 1]);
-            $mform->setType('courses[' . $course->id . ']', PARAM_BOOL);
+            $checkboxname = 'courses[' . $course->id . ']';
+            $mform->addElement('advcheckbox', $checkboxname, '', $label, [
+                'group' => 1,
+                'class' => 'course-checkbox'
+            ]);
+            $mform->setType($checkboxname, PARAM_BOOL);
+            if (isset($selection[$course->id])) {
+                $mform->setDefault($checkboxname, 1);
+            }
         }
         if (!empty($catids)) {
             $mform->addElement('hidden', 'catids', implode(',', $catids));

--- a/local/downloadcenter/download_form.php
+++ b/local/downloadcenter/download_form.php
@@ -40,6 +40,7 @@ class local_downloadcenter_download_form extends moodleform {
         $mform = $this->_form;
 
         $resources = $this->_customdata['res'];
+        $selection = $this->_customdata['selection'] ?? [];
 
         $mform->addElement('hidden', 'courseid', $COURSE->id);
         $mform->setType('courseid', PARAM_INT);
@@ -64,14 +65,14 @@ class local_downloadcenter_download_form extends moodleform {
             $mform->addElement('html', html_writer::start_tag('div', array('class' => 'card block mb-3')));
             $sectiontitle = html_writer::span($sectioninfo->title, 'sectiontitle');
             $mform->addElement('checkbox', $sectionname, $sectiontitle);
+            $mform->setDefault($sectionname, isset($selection[$sectionname]));
 
-            $mform->setDefault($sectionname, 1);
             foreach ($sectioninfo->res as $res) {
                 $name = 'item_' . $res->modname . '_' . $res->instanceid;
                 $title = html_writer::span($res->name) . ' ' . $res->icon;
                 $title = html_writer::tag('span', $title, array('class' => 'itemtitle'));
                 $mform->addElement('checkbox', $name, $title);
-                $mform->setDefault($name, 1);
+                $mform->setDefault($name, isset($selection[$name]));
             }
             $mform->addElement('html', html_writer::end_tag('div'));
         }

--- a/local/downloadcenter/index.php
+++ b/local/downloadcenter/index.php
@@ -206,16 +206,17 @@ if ($courseid) {
 
     $downloadcenter = new local_downloadcenter_factory($course, $USER);
     $userresources = $downloadcenter->get_resources_for_user();
-    
+
     // Cargar JavaScript para filtros
-    $PAGE->requires->js_call_amd('local_downloadcenter/modfilter', 'init', 
+    $PAGE->requires->js_call_amd('local_downloadcenter/modfilter', 'init',
                                  $downloadcenter->get_js_modnames());
 
+    $courseselection = $selection[$courseid] ?? [];
     $downloadform = new local_downloadcenter_download_form(
-        null, 
-        ['res' => $userresources], 
-        'post', 
-        '', 
+        null,
+        ['res' => $userresources, 'selection' => $courseselection],
+        'post',
+        '',
         ['data-double-submit-protection' => 'off']
     );
 
@@ -290,6 +291,12 @@ function local_downloadcenter_render_category_tree(\core_course_category $catego
         });
     }
 
+    // Determine category checkbox state based on selected courses.
+    $allcourseids = array_keys($category->get_courses(['recursive' => true]));
+    $selectedcourseids = array_intersect($allcourseids, array_keys($selection));
+    $catchecked = !empty($allcourseids) && count($selectedcourseids) === count($allcourseids);
+    $catindeterminate = !empty($selectedcourseids) && !$catchecked;
+
     $courseform = new local_downloadcenter_course_select_form(null, [
         'courses' => $courses,
         'selection' => $selection,
@@ -329,17 +336,27 @@ function local_downloadcenter_render_category_tree(\core_course_category $catego
     }
 
     $collapseid = 'cat' . $category->id;
-    $html = html_writer::start_div('card mb-2');
-    $html .= html_writer::tag('div',
-        html_writer::tag('button', $category->get_formatted_name(), [
-            'class' => 'btn btn-link text-left w-100',
-            'data-toggle' => 'collapse',
-            'data-target' => '#' . $collapseid,
-            'aria-expanded' => 'false',
-            'aria-controls' => $collapseid,
-        ]),
-        ['class' => 'card-header p-0']
-    );
+    $checkboxattrs = [
+        'type' => 'checkbox',
+        'class' => 'downloadcenter-category-checkbox mr-2',
+        'data-categoryid' => $category->id,
+    ];
+    if ($catchecked) {
+        $checkboxattrs['checked'] = 'checked';
+    }
+    if ($catindeterminate) {
+        $checkboxattrs['data-indeterminate'] = 1;
+    }
+    $button = html_writer::tag('button', $category->get_formatted_name(), [
+        'class' => 'btn btn-link text-left w-100',
+        'data-toggle' => 'collapse',
+        'data-target' => '#' . $collapseid,
+        'aria-expanded' => 'false',
+        'aria-controls' => $collapseid,
+    ]);
+    $header = html_writer::empty_tag('input', $checkboxattrs) . $button;
+    $html = html_writer::start_div('card mb-2 downloadcenter-category');
+    $html .= html_writer::tag('div', $header, ['class' => 'card-header p-0 d-flex align-items-center']);
     $html .= html_writer::start_div('collapse', ['id' => $collapseid]);
     $html .= html_writer::div($innerhtml, 'card-body');
     $html .= html_writer::end_div();
@@ -357,6 +374,9 @@ if (!empty($catids)) {
     $PAGE->navbar->add(get_string('courses'), new moodle_url('/course/management.php'));
     $PAGE->navbar->add(get_string('navigationlink', 'local_downloadcenter'),
                       local_downloadcenter_build_url($catids));
+
+    // JavaScript for category checkbox tree.
+    $PAGE->requires->js_call_amd('local_downloadcenter/category_tree', 'init');
 
     echo $OUTPUT->header();
 
@@ -384,7 +404,7 @@ if (!empty($catids)) {
         'type' => 'text',
         'name' => 'search',
         'class' => 'form-control',
-        'placeholder' => get_string('searchcourses'),
+        'placeholder' => get_string('searchcourses', 'local_downloadcenter'),
         'value' => $search
     ]);
     echo html_writer::start_div('input-group-append');


### PR DESCRIPTION
## Summary
- allow selecting categories with tri-state checkboxes and client-side hierarchy management
- remember chosen course resources when revisiting download page
- mark previously chosen courses in selection lists
- update category tree module and remove committed binaries
- use plugin-specific string for course search placeholder

## Testing
- `php -l local/downloadcenter/index.php`
- `php -l local/downloadcenter/course_select_form.php`
- `php -l local/downloadcenter/download_form.php`
- `vendor/bin/phpunit local_downloadcenter_files_visible_testcase local/downloadcenter/tests/files_visible_test.php` *(fails: No such file or directory)*
- `npx grunt amd` *(fails: Node version not satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_68a64ff7eb64832ab1bec304f4d40ab2