### PR TITLE
feat: add hierarchical category selection

### DIFF
--- a/local/downloadcenter/amd/src/category_tree.js
+++ b/local/downloadcenter/amd/src/category_tree.js
@@ -1,0 +1,59 @@
+/**
+ * Manage tri-state category checkboxes on the download center page.
+ *
+ * @module     local_downloadcenter/category_tree
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+define(['jquery'], function($) {
+    'use strict';
+
+    function updateCategoryState($checkbox) {
+        var $container = $checkbox.closest('.downloadcenter-category');
+        var $courseboxes = $container.find('> .collapse > .card-body > form .course-checkbox');
+        var $childcategories = $container.find('> .collapse > .card-body > .downloadcenter-category');
+        var $subcatboxes = $childcategories.find('> .card-header input.downloadcenter-category-checkbox');
+        var total = $courseboxes.length + $subcatboxes.length;
+        var checked = $courseboxes.filter(':checked').length + $subcatboxes.filter(':checked').length;
+        var indeterminateChildren = $subcatboxes.filter(function() { return this.indeterminate; }).length;
+        $checkbox.prop('checked', total > 0 && checked === total);
+        $checkbox.prop('indeterminate', (checked > 0 && checked < total) || indeterminateChildren > 0);
+    }
+
+    function propagateToChildren($checkbox, checked) {
+        var $container = $checkbox.closest('.downloadcenter-category');
+        $container.find('.course-checkbox, .downloadcenter-category-checkbox').not($checkbox).each(function() {
+            this.checked = checked;
+            this.indeterminate = false;
+            $(this).trigger('change');
+        });
+    }
+
+    return {
+        init: function() {
+            $('.downloadcenter-category').each(function() {
+                var $cat = $(this);
+                var $catbox = $cat.find('> .card-header input.downloadcenter-category-checkbox');
+                if ($catbox.data('indeterminate')) {
+                    $catbox.prop('indeterminate', true);
+                }
+                $catbox.on('change', function() {
+                    propagateToChildren($catbox, $catbox.is(':checked'));
+                    var $current = $catbox.closest('.downloadcenter-category').parents('.downloadcenter-category').first();
+                    while ($current.length) {
+                        var $parentbox = $current.find('> .card-header input.downloadcenter-category-checkbox');
+                        updateCategoryState($parentbox);
+                        $current = $current.parents('.downloadcenter-category').first();
+                    }
+                });
+                $cat.find('.course-checkbox').on('change', function() {
+                    var $current = $(this).closest('.downloadcenter-category');
+                    while ($current.length) {
+                        var $parentbox = $current.find('> .card-header input.downloadcenter-category-checkbox');
+                        updateCategoryState($parentbox);
+                        $current = $current.parents('.downloadcenter-category').first();
+                    }
+                });
+            });
+        }
+    };
+});

--- a/local/downloadcenter/amd/src/section_tree.js
+++ b/local/downloadcenter/amd/src/section_tree.js
@@ -1,0 +1,42 @@
+/**
+ * Manage section and item checkboxes with tri-state behaviour on the course page.
+ *
+ * @module     local_downloadcenter/section_tree
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+ define(['jquery'], function($) {
+     'use strict';
+ 
+     function updateSectionState(section) {
+         var $items = $('input.item-checkbox[data-section="' + section + '"]');
+         var $sectionbox = $('input.section-checkbox[data-section="' + section + '"]');
+         var checked = $items.filter(':checked').length;
+         var total = $items.length;
+         $sectionbox.prop('checked', checked > 0);
+         $sectionbox.prop('indeterminate', checked > 0 && checked < total);
+         if (checked > 0 && checked < total) {
+             $sectionbox.prop('checked', true);
+         }
+     }
+ 
+     return {
+         init: function() {
+             $('input.section-checkbox').each(function() {
+                 var section = $(this).data('section');
+                 if ($(this).data('indeterminate')) {
+                     $(this).prop('indeterminate', true);
+                 }
+                 $(this).on('change', function() {
+                     var checked = $(this).is(':checked');
+                     $('input.item-checkbox[data-section="' + section + '"]').prop({
+                         checked: checked
+                     }).trigger('change');
+                     $(this).prop('indeterminate', false);
+                 });
+             });
+             $('input.item-checkbox').on('change', function() {
+                 updateSectionState($(this).data('section'));
+             });
+         }
+     };
+ });

--- a/local/downloadcenter/course_select_form.php
+++ b/local/downloadcenter/course_select_form.php
@@ -39,8 +39,18 @@ class local_downloadcenter_course_select_form extends moodleform {
             if (isset($selection[$course->id])) {
                 $label .= ' (' . get_string('selected', 'local_downloadcenter') . ')';
             }
-            $mform->addElement('advcheckbox', 'courses[' . $course->id . ']', '', $label, ['group' => 1]);
-            $mform->setType('courses[' . $course->id . ']', PARAM_BOOL);
+            $checkboxname = 'courses[' . $course->id . ']';
+            $mform->addElement('advcheckbox', $checkboxname, '', $label, [
+                'group' => 1,
+                'class' => 'course-checkbox'
+            ]);
+            $mform->setType($checkboxname, PARAM_BOOL);
+            if (isset($selection[$course->id])) {
+                $mform->setDefault($checkboxname, 1);
+            }
+        }
+        if (!empty($courses)) {
+            $mform->add_checkbox_controller(1);
         }
         if (!empty($catids)) {
             $mform->addElement('hidden', 'catids', implode(',', $catids));

--- a/local/downloadcenter/download_form.php
+++ b/local/downloadcenter/download_form.php
@@ -40,6 +40,7 @@ class local_downloadcenter_download_form extends moodleform {
         $mform = $this->_form;
 
         $resources = $this->_customdata['res'];
+        $selection = $this->_customdata['selection'] ?? [];
 
         $mform->addElement('hidden', 'courseid', $COURSE->id);
         $mform->setType('courseid', PARAM_INT);
@@ -63,15 +64,31 @@ class local_downloadcenter_download_form extends moodleform {
             $sectionname = 'item_topic_' . $sectionid;
             $mform->addElement('html', html_writer::start_tag('div', array('class' => 'card block mb-3')));
             $sectiontitle = html_writer::span($sectioninfo->title, 'sectiontitle');
-            $mform->addElement('checkbox', $sectionname, $sectiontitle);
 
-            $mform->setDefault($sectionname, 1);
+            $totalitems = count($sectioninfo->res);
+            $selecteditems = 0;
+            foreach ($sectioninfo->res as $res) {
+                $name = 'item_' . $res->modname . '_' . $res->instanceid;
+                if (isset($selection[$name])) {
+                    $selecteditems++;
+                }
+            }
+            $sectionattrs = array('class' => 'section-checkbox', 'data-section' => $sectionid);
+            if ($selecteditems > 0) {
+                $mform->setDefault($sectionname, 1);
+                if ($selecteditems < $totalitems) {
+                    $sectionattrs['data-indeterminate'] = 1;
+                }
+            }
+            $mform->addElement('checkbox', $sectionname, $sectiontitle, '', $sectionattrs);
+
             foreach ($sectioninfo->res as $res) {
                 $name = 'item_' . $res->modname . '_' . $res->instanceid;
                 $title = html_writer::span($res->name) . ' ' . $res->icon;
                 $title = html_writer::tag('span', $title, array('class' => 'itemtitle'));
-                $mform->addElement('checkbox', $name, $title);
-                $mform->setDefault($name, 1);
+                $itemattrs = array('class' => 'item-checkbox', 'data-section' => $sectionid);
+                $mform->addElement('checkbox', $name, $title, '', $itemattrs);
+                $mform->setDefault($name, isset($selection[$name]));
             }
             $mform->addElement('html', html_writer::end_tag('div'));
         }


### PR DESCRIPTION
## Summary
- allow selecting categories with tri-state checkboxes and client-side hierarchy management
- remember chosen course resources when revisiting download page
- mark previously chosen courses in selection lists
- update category tree module and remove committed binaries
- use plugin-specific string for course search placeholder
- enable deselecting courses and tri-state section selection within courses
- correctly compute checkbox state when categories contain nested subcategories

## Testing
- `php -l local/downloadcenter/index.php`
- `php -l local/downloadcenter/course_select_form.php`
- `php -l local/downloadcenter/download_form.php`
- `php -l local/downloadcenter/category_select_form.php`
- `npx -y terser local/downloadcenter/amd/src/category_tree.js > /dev/null`
- `npx -y terser local/downloadcenter/amd/src/section_tree.js > /dev/null`
- `vendor/bin/phpunit local_downloadcenter_files_visible_testcase local/downloadcenter/tests/files_visible_test.php` *(fails: No such file or directory)*
- `npx -y grunt amd` *(fails: Unable to find local grunt)*

------
https://chatgpt.com/codex/tasks/task_e_68a64ff7eb64832ab1bec304f4d40ab2