### PR TITLE
feat: persist course selections and simplify navigation

### DIFF
--- a/local/downloadcenter/amd/src/category_tree.js
+++ b/local/downloadcenter/amd/src/category_tree.js
@@ -4,7 +4,7 @@
  * @module     local_downloadcenter/category_tree
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-define(['jquery'], function($) {
+define(['jquery', 'core_form/changechecker'], function($, changechecker) {
     'use strict';
 
     function updateCategoryState($checkbox) {
@@ -45,13 +45,26 @@ define(['jquery'], function($) {
                         $current = $current.parents('.downloadcenter-category').first();
                     }
                 });
-                $cat.find('.course-checkbox').on('change', function() {
-                    var $current = $(this).closest('.downloadcenter-category');
+                $cat.find('.course-checkbox').each(function() {
+                    if ($(this).data('indeterminate')) {
+                        $(this).prop('indeterminate', true);
+                    }
+                }).on('change', function() {
+                    var $checkbox = $(this);
+                    var $current = $checkbox.closest('.downloadcenter-category');
                     while ($current.length) {
                         var $parentbox = $current.find('> .card-header input.downloadcenter-category-checkbox');
                         updateCategoryState($parentbox);
                         $current = $current.parents('.downloadcenter-category').first();
                     }
+                    $.post(M.cfg.wwwroot + '/local/downloadcenter/index.php', {
+                        action: 'togglecourse',
+                        courseid: $checkbox.data('courseid'),
+                        checked: $checkbox.is(':checked') ? 1 : 0,
+                        sesskey: M.cfg.sesskey
+                    }).done(function() {
+                        changechecker.resetFormDirtyState($checkbox.closest('form')[0]);
+                    });
                 });
             });
         }

--- a/local/downloadcenter/amd/src/section_tree.js
+++ b/local/downloadcenter/amd/src/section_tree.js
@@ -4,7 +4,7 @@
  * @module     local_downloadcenter/section_tree
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
- define(['jquery'], function($) {
+ define(['jquery', 'core_form/changechecker'], function($, changechecker) {
      'use strict';
  
      function updateSectionState(section) {
@@ -21,6 +21,14 @@
  
      return {
          init: function() {
+             var $form = $('form');
+             function saveForm() {
+                 var data = $form.serializeArray();
+                 data.push({name: 'action', value: 'savecourse'});
+                 $.post(M.cfg.wwwroot + '/local/downloadcenter/index.php', $.param(data))
+                     .done(function() { changechecker.resetFormDirtyState($form[0]); });
+             }
+
              $('input.section-checkbox').each(function() {
                  var section = $(this).data('section');
                  if ($(this).data('indeterminate')) {
@@ -32,11 +40,13 @@
                          checked: checked
                      }).trigger('change');
                      $(this).prop('indeterminate', false);
+                     saveForm();
                  });
              });
              $('input.item-checkbox').on('change', function() {
                  updateSectionState($(this).data('section'));
+                 saveForm();
              });
-         }
-     };
- });
+        }
+    };
+});

--- a/local/downloadcenter/course_select_form.php
+++ b/local/downloadcenter/course_select_form.php
@@ -40,13 +40,18 @@ class local_downloadcenter_course_select_form extends moodleform {
                 $label .= ' (' . get_string('selected', 'local_downloadcenter') . ')';
             }
             $checkboxname = 'courses[' . $course->id . ']';
-            $mform->addElement('advcheckbox', $checkboxname, '', $label, [
+            $attrs = [
                 'group' => 1,
-                'class' => 'course-checkbox'
-            ]);
+                'class' => 'course-checkbox',
+                'data-courseid' => $course->id
+            ];
+            $mform->addElement('advcheckbox', $checkboxname, '', $label, $attrs);
             $mform->setType($checkboxname, PARAM_BOOL);
             if (isset($selection[$course->id])) {
                 $mform->setDefault($checkboxname, 1);
+                if (empty($selection[$course->id]['downloadall'])) {
+                    $mform->updateElementAttr($checkboxname, ['data-indeterminate' => 1]);
+                }
             }
         }
         if (!empty($courses)) {

--- a/local/downloadcenter/download_form.php
+++ b/local/downloadcenter/download_form.php
@@ -94,7 +94,8 @@ class local_downloadcenter_download_form extends moodleform {
         if ($empty) {
             $mform->addElement('html', html_writer::tag('h2', get_string('no_downloadable_content', 'local_downloadcenter')));
         }
-        $this->add_action_buttons(true, get_string('createzip', 'local_downloadcenter'));
+        // Save selection instead of creating the ZIP directly.
+        $this->add_action_buttons(true, get_string('saveselection', 'local_downloadcenter'));
 
     }
 }

--- a/local/downloadcenter/lang/en/local_downloadcenter.php
+++ b/local/downloadcenter/lang/en/local_downloadcenter.php
@@ -42,6 +42,7 @@ $string['includeassignments_desc'] = 'Include assignment descriptions and intro 
 // Interface strings
 $string['warningmessage'] = 'Here you can download single or all available contents of this course in a ZIP archive.';
 $string['createzip'] = 'Create ZIP archive';
+$string['saveselection'] = 'Save selection';
 $string['zipready'] = 'The ZIP archive has been successfully created.';
 $string['download'] = 'Download';
 $string['zipcreating'] = 'The ZIP archive is being created...';

--- a/local/downloadcenter/lang/es/local_downloadcenter.php
+++ b/local/downloadcenter/lang/es/local_downloadcenter.php
@@ -42,6 +42,7 @@ $string['includeassignments_desc'] = 'Incluye las descripciones de las tareas y 
 // Interface strings
 $string['warningmessage'] = 'Aquí puede descargar en un archivo ZIP uno o todos los contenidos disponibles de este curso.';
 $string['createzip'] = 'Crear archivo ZIP';
+$string['saveselection'] = 'Guardar selección';
 $string['zipready'] = 'El archivo ZIP se creó correctamente.';
 $string['download'] = 'Descargar';
 $string['zipcreating'] = 'Creando el archivo ZIP...';


### PR DESCRIPTION
## Summary
- Show all categories by default and add AJAX endpoints for course selection persistence
- Track partial course selections and auto-save changes with new JS handlers
- Rename course action to **Save selection** and add corresponding language strings

## Testing
- `php -l local/downloadcenter/index.php`
- `php -l local/downloadcenter/course_select_form.php`
- `php -l local/downloadcenter/download_form.php`
- `php -l local/downloadcenter/lang/en/local_downloadcenter.php`
- `php -l local/downloadcenter/lang/es/local_downloadcenter.php`
- `vendor/bin/phpunit local_downloadcenter\tests\files_visible_test.php` *(fails: No such file or directory)*
- `composer install` *(fails: ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abdb76ae1c832a80e3650af9ab5508