### PR TITLE
Add remaining PayU Colombia payment methods

### DIFF
--- a/payment/gateway/payu/README.md
+++ b/payment/gateway/payu/README.md
@@ -1,0 +1,14 @@
+# PayU Colombia payment gateway
+
+This is an experimental payment gateway for connecting Moodle to the PayU platform in Colombia. It is based on the structure of existing payment gateway plugins such as `paygw_payanyway` and `paygw_stripe`.
+
+The plugin currently provides an in-site checkout that submits transactions directly to PayU's API.
+Each payment method is rendered via a Mustache template located in `templates/` so the forms can
+be customised through Moodle's standard theming system. It supports credit-card payments, PSE bank
+transfers, Nequi, the Bancolombia button, Google Pay and cash-based options like Efecty, all inside Moodle
+without redirecting through the PayU Web Checkout. Buyer and payer data such as document number,
+phone and address are sent with each request as required by PayU. The code is based on `paygw_payanyway` and
+`paygw_stripe`.
+
+Further work is required to cover additional payment methods and advanced features such as
+subscriptions or refunds.

--- a/payment/gateway/payu/callback.php
+++ b/payment/gateway/payu/callback.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Handles PayU payment notifications.
+ *
+ * @package     paygw_payu
+ * @copyright   2024 Example
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use core_payment\helper;
+
+require(__DIR__ . '/../../../config.php');
+
+global $DB;
+
+$reference = required_param('reference_sale', PARAM_INT);
+$signature = required_param('sign', PARAM_RAW);
+$value = required_param('value', PARAM_RAW);
+$currency = required_param('currency', PARAM_TEXT);
+$state = required_param('state_pol', PARAM_INT);
+$merchantid = required_param('merchant_id', PARAM_INT);
+
+if (!$payment = $DB->get_record('payments', ['id' => $reference])) {
+    die('ERROR: invalid reference');
+}
+
+$component = $payment->component;
+$paymentarea = $payment->paymentarea;
+$itemid = $payment->itemid;
+$config = (object) helper::get_gateway_configuration($component, $paymentarea, $itemid, 'payu');
+
+if ((int)$merchantid !== (int)$config->merchantid) {
+    die('ERROR: invalid merchant');
+}
+
+$formattedvalue = number_format((float)$value, 2, '.', '');
+$localsign = md5($config->apikey . '~' . $merchantid . '~' . $reference . '~' . $formattedvalue . '~' . $currency . '~' . $state);
+if (strtoupper($localsign) !== strtoupper($signature)) {
+    die('ERROR: invalid signature');
+}
+
+if ((int)$state === 4) { // 4 means approved.
+    helper::deliver_order($component, $paymentarea, $itemid, $payment->id, $payment->userid);
+    echo 'OK';
+} else {
+    echo 'IGNORED';
+}

--- a/payment/gateway/payu/classes/api.php
+++ b/payment/gateway/payu/classes/api.php
@@ -1,0 +1,237 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Low level PayU API helper.
+ *
+ * This is a minimal client used to submit transactions directly to
+ * PayU without using the hosted checkout.
+ *
+ * @package    paygw_payu
+ * @copyright  2024 Example
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace paygw_payu;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Helper class for communicating with PayU.
+ */
+class api {
+
+    /**
+     * Retrieves the list of PSE banks from PayU.
+     *
+     * @param \stdClass $config Gateway configuration.
+     * @return array Array of pseCode => description.
+     */
+    public static function get_pse_banks(\stdClass $config): array {
+        $request = [
+            'language' => 'es',
+            'command' => 'GET_BANKS_LIST',
+            'merchant' => [
+                'apiLogin' => $config->apilogin,
+                'apiKey' => $config->apikey,
+            ],
+            'test' => !empty($config->testmode),
+            'bankListInformation' => [
+                'paymentMethod' => 'PSE',
+                'paymentCountry' => 'CO',
+            ],
+        ];
+
+        $endpoint = !empty($config->testmode) ?
+            'https://sandbox.api.payulatam.com/payments-api/4.0/service.cgi' :
+            'https://api.payulatam.com/payments-api/4.0/service.cgi';
+
+        $ch = curl_init($endpoint);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($request));
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        $banks = [];
+        if ($response) {
+            $result = json_decode($response);
+            if (!empty($result->banks)) {
+                foreach ($result->banks as $bank) {
+                    if (!empty($bank->pseCode) && !empty($bank->description)) {
+                        $banks[$bank->pseCode] = $bank->description;
+                    }
+                }
+            }
+        }
+
+        return $banks;
+    }
+
+    /**
+     * Submits a transaction to PayU.
+     *
+     * @param \stdClass $config Gateway configuration.
+     * @param int $paymentid Local payment record id.
+     * @param float $amount Amount to charge.
+     * @param string $currency ISO currency code.
+     * @param \stdClass $formdata Data collected from the checkout form.
+     * @return \stdClass|null Transaction response or null on failure.
+     */
+    public static function submit_transaction(\stdClass $config, int $paymentid, float $amount,
+            string $currency, \stdClass $formdata): ?\stdClass {
+        global $USER;
+
+        $address = [
+            'street1' => $USER->address ?? 'N/A',
+            'city' => $USER->city ?? 'Bogota',
+            'state' => $USER->state ?? ($USER->city ?? 'Bogota'),
+            'country' => $USER->country ?? 'CO',
+            'postalCode' => '000000',
+            'phone' => $formdata->phone ?? '',
+        ];
+
+        $request = [
+            'language' => 'es',
+            'command' => 'SUBMIT_TRANSACTION',
+            'merchant' => [
+                'apiLogin' => $config->apilogin,
+                'apiKey' => $config->apikey,
+            ],
+            'test' => !empty($config->testmode),
+            'transaction' => [
+                'order' => [
+                    'accountId' => $config->accountid,
+                    'referenceCode' => (string) $paymentid,
+                    'description' => $formdata->description ?? '',
+                    'language' => 'es',
+                    'signature' => md5($config->apikey . '~' . $config->merchantid . '~' . $paymentid .
+                        '~' . number_format($amount, 2, '.', '') . '~' . $currency),
+                    'notifyUrl' => (new \moodle_url('/payment/gateway/payu/callback.php'))->out(false),
+                    'additionalValues' => [
+                        'TX_VALUE' => [
+                            'value' => $amount,
+                            'currency' => $currency,
+                        ],
+                        'TX_TAX' => [
+                            'value' => 0,
+                            'currency' => $currency,
+                        ],
+                        'TX_TAX_RETURN_BASE' => [
+                            'value' => 0,
+                            'currency' => $currency,
+                        ],
+                    ],
+                    'buyer' => [
+                        'fullName' => $formdata->cardholder,
+                        'emailAddress' => $formdata->email ?? '',
+                        'contactPhone' => $formdata->phone ?? '',
+                        'dniNumber' => $formdata->documentnumber ?? '',
+                        'shippingAddress' => $address,
+                    ],
+                    'shippingAddress' => $address,
+                ],
+                'type' => 'AUTHORIZATION_AND_CAPTURE',
+                'paymentCountry' => 'CO',
+                'ipAddress' => $_SERVER['REMOTE_ADDR'] ?? '',
+                'deviceSessionId' => session_id(),
+                'cookie' => session_id(),
+                'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+                'payer' => [
+                    'fullName' => $formdata->cardholder,
+                    'emailAddress' => $formdata->email ?? '',
+                    'contactPhone' => $formdata->phone ?? '',
+                    'dniNumber' => $formdata->documentnumber ?? '',
+                    'billingAddress' => $address,
+                ],
+            ],
+        ];
+
+        if ($formdata->paymentmethod === 'creditcard') {
+            $request['transaction']['paymentMethod'] = $formdata->cardnetwork;
+            $request['transaction']['creditCard'] = [
+                'number' => $formdata->ccnumber,
+                'securityCode' => $formdata->cvv,
+                'expirationDate' => $formdata->ccexpyear . '/' . $formdata->ccexpmonth,
+                'name' => $formdata->cardholder,
+            ];
+            $request['transaction']['payer']['contactPhone'] = $formdata->phone ?? '';
+            $request['transaction']['payer']['dniNumber'] = $formdata->documentnumber ?? '';
+            $request['transaction']['extraParameters'] = [
+                'INSTALLMENTS_NUMBER' => 1,
+            ];
+        } else if ($formdata->paymentmethod === 'pse') {
+            global $CFG;
+            $request['transaction']['paymentMethod'] = 'PSE';
+            $request['transaction']['payer']['contactPhone'] = $formdata->phone;
+            $request['transaction']['payer']['dniNumber'] = $formdata->documentnumber;
+            $request['transaction']['extraParameters'] = [
+                'RESPONSE_URL' => $CFG->wwwroot . '/payment/gateway/payu/return.php',
+                'FINANCIAL_INSTITUTION_CODE' => $formdata->psebank,
+                'USER_TYPE' => $formdata->usertype,
+                'PSE_REFERENCE1' => $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1',
+                'PSE_REFERENCE2' => $formdata->documenttype,
+                'PSE_REFERENCE3' => $formdata->documentnumber,
+            ];
+        } else if ($formdata->paymentmethod === 'nequi') {
+            $request['transaction']['paymentMethod'] = 'NEQUI';
+            $request['transaction']['payer']['contactPhone'] = $formdata->phone;
+        } else if ($formdata->paymentmethod === 'bancolombia') {
+            $request['transaction']['paymentMethod'] = 'BANCOLOMBIA_BUTTON';
+            $request['transaction']['payer']['contactPhone'] = $formdata->phone;
+        } else if ($formdata->paymentmethod === 'googlepay') {
+            $request['transaction']['paymentMethod'] = $formdata->gp_network;
+            $request['transaction']['creditCard'] = [
+                'name' => $formdata->cardholder,
+            ];
+            $request['transaction']['digitalWallet'] = [
+                'type' => 'GOOGLE_PAY',
+                'message' => $formdata->gp_token,
+            ];
+            $request['transaction']['extraParameters'] = [
+                'INSTALLMENTS_NUMBER' => 1,
+            ];
+        } else if ($formdata->paymentmethod === 'cash') {
+            $request['transaction']['paymentMethod'] = $formdata->cashmethod;
+            $request['transaction']['payer']['contactPhone'] = $formdata->phone;
+            $request['transaction']['expirationDate'] = date('Y-m-d\TH:i:s', strtotime('+7 days'));
+        } else {
+            $request['transaction']['paymentMethod'] = strtoupper($formdata->paymentmethod);
+        }
+
+        $endpoint = !empty($config->testmode) ?
+            'https://sandbox.api.payulatam.com/payments-api/4.0/service.cgi' :
+            'https://api.payulatam.com/payments-api/4.0/service.cgi';
+
+        $ch = curl_init($endpoint);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($request));
+        $response = curl_exec($ch);
+        $info = curl_getinfo($ch);
+        curl_close($ch);
+
+        if ($info['http_code'] != 200 || empty($response)) {
+            return null;
+        }
+
+        $result = json_decode($response);
+        return $result->transactionResponse ?? null;
+    }
+}
+

--- a/payment/gateway/payu/classes/gateway.php
+++ b/payment/gateway/payu/classes/gateway.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Contains class for PayU Colombia payment gateway.
+ *
+ * @package    paygw_payu
+ * @copyright  2024 Example
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace paygw_payu;
+
+use core_payment\form\account_gateway;
+
+/**
+ * The gateway class for the PayU Colombia payment gateway.
+ */
+class gateway extends \core_payment\gateway {
+    /**
+     * Return currencies supported by PayU.
+     *
+     * @return string[]
+     */
+    public static function get_supported_currencies(): array {
+        return ['COP', 'USD'];
+    }
+
+    /**
+     * Adds configuration fields to the gateway form.
+     *
+     * @param account_gateway $form
+     */
+    public static function add_configuration_to_gateway_form(account_gateway $form): void {
+        $mform = $form->get_mform();
+
+        $mform->addElement('text', 'merchantid', get_string('merchantid', 'paygw_payu'));
+        $mform->setType('merchantid', PARAM_TEXT);
+        $mform->addRule('merchantid', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('text', 'accountid', get_string('accountid', 'paygw_payu'));
+        $mform->setType('accountid', PARAM_TEXT);
+        $mform->addRule('accountid', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('text', 'apilogin', get_string('apilogin', 'paygw_payu'));
+        $mform->setType('apilogin', PARAM_TEXT);
+        $mform->addRule('apilogin', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('passwordunmask', 'apikey', get_string('apikey', 'paygw_payu'));
+        $mform->setType('apikey', PARAM_TEXT);
+        $mform->addRule('apikey', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('advcheckbox', 'testmode', get_string('testmode', 'paygw_payu'));
+        $mform->setType('testmode', PARAM_BOOL);
+    }
+
+    /**
+     * Validates the gateway configuration form.
+     *
+     * @param account_gateway $form
+     * @param \stdClass $data
+     * @param array $files
+     * @param array $errors
+     */
+    public static function validate_gateway_form(account_gateway $form, \stdClass $data, array $files, array &$errors): void {
+        if ($data->enabled && (empty($data->merchantid) || empty($data->accountid) || empty($data->apilogin) || empty($data->apikey))) {
+            $errors['enabled'] = get_string('gatewaycannotbeenabled', 'payment');
+        }
+    }
+}

--- a/payment/gateway/payu/lang/en/paygw_payu.php
+++ b/payment/gateway/payu/lang/en/paygw_payu.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'paygw_payu', language 'en'
+ *
+ * @package     paygw_payu
+ * @copyright   2024 Example
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['gatewayname'] = 'PayU Colombia';
+$string['pluginname'] = 'PayU Colombia payment';
+$string['pluginname_desc'] = 'The PayU Colombia plugin allows you to receive payments through PayU in Colombia.';
+$string['merchantid'] = 'Merchant ID';
+$string['accountid'] = 'Account ID';
+$string['apikey'] = 'API key';
+$string['apilogin'] = 'API login';
+$string['testmode'] = 'Test mode';
+$string['gatewaydescription'] = 'PayU is a leading payment service provider in Colombia.';
+$string['sendpaymentbutton'] = 'Pay with PayU';
+$string['privacy:metadata'] = 'The PayU payment gateway does not store personal data.';
+$string['payment'] = 'Return to site';
+
+$string['paymentmethod'] = 'Payment method';
+$string['creditcard'] = 'Credit card';
+$string['pse'] = 'Bank transfer (PSE)';
+$string['nequi'] = 'Nequi';
+$string['bancolombia'] = 'Bancolombia button';
+$string['googlepay'] = 'Google Pay';
+$string['cash'] = 'Cash';
+$string['cardnumber'] = 'Card number';
+$string['expmonth'] = 'Expiry month';
+$string['expyear'] = 'Expiry year';
+$string['cvv'] = 'CVV';
+$string['cardholder'] = 'Cardholder name';
+$string['submitpayment'] = 'Submit payment';
+$string['missingccfields'] = 'Please complete all credit card fields.';
+$string['psebank'] = 'Bank';
+$string['usertype'] = 'User type';
+$string['personnatural'] = 'Natural person';
+$string['personjuridica'] = 'Legal person';
+$string['documenttype'] = 'Document type';
+$string['documentnumber'] = 'Document number';
+$string['phone'] = 'Phone number';
+$string['missingpsefields'] = 'Please complete all PSE fields.';
+$string['cashmethod'] = 'Cash method';
+$string['efecty'] = 'Efecty';
+$string['otherscash'] = 'Other cash networks';
+$string['bankreferenced'] = 'Bank reference';
+$string['cardnetwork'] = 'Card network';
+$string['googlepaytoken'] = 'Google Pay token';
+$string['paymenterror'] = 'Unable to process payment.';
+$string['paymentpending'] = 'Your payment is pending; you will be redirected to complete it.';

--- a/payment/gateway/payu/pay.php
+++ b/payment/gateway/payu/pay.php
@@ -1,0 +1,130 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Internal checkout flow for PayU payments.
+ *
+ * @package    paygw_payu
+ * @copyright  2024 Example
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use core_payment\helper;
+use paygw_payu\api;
+
+require_once(__DIR__ . '/../../../config.php');
+
+require_login();
+require_sesskey();
+
+$component   = required_param('component', PARAM_COMPONENT);
+$paymentarea = required_param('paymentarea', PARAM_AREA);
+$itemid      = required_param('itemid', PARAM_INT);
+$description = required_param('description', PARAM_TEXT);
+$description = json_decode('"' . $description . '"');
+
+$config = (object) helper::get_gateway_configuration($component, $paymentarea, $itemid, 'payu');
+$payable = helper::get_payable($component, $paymentarea, $itemid);
+$currency = $payable->get_currency();
+$surcharge = helper::get_gateway_surcharge('payu');
+$amount = helper::get_rounded_cost($payable->get_amount(), $currency, $surcharge);
+
+$paymentid = helper::save_payment(
+    $payable->get_account_id(),
+    $component,
+    $paymentarea,
+    $itemid,
+    $USER->id,
+    $amount,
+    $currency,
+    'payu'
+);
+
+if (optional_param('paymentmethod', null, PARAM_ALPHA)) {
+    $method = required_param('paymentmethod', PARAM_ALPHA);
+    $formdata = new stdClass();
+    $formdata->paymentmethod = $method;
+    $formdata->cardholder = required_param('cardholder', PARAM_TEXT);
+    if ($method === 'creditcard') {
+        $formdata->ccnumber = required_param('ccnumber', PARAM_TEXT);
+        $formdata->ccexpmonth = required_param('ccexpmonth', PARAM_TEXT);
+        $formdata->ccexpyear = required_param('ccexpyear', PARAM_TEXT);
+        $formdata->cvv = required_param('cvv', PARAM_TEXT);
+        $formdata->cardnetwork = required_param('cardnetwork', PARAM_ALPHANUMEXT);
+        $formdata->phone = required_param('phone', PARAM_TEXT);
+        $formdata->documentnumber = required_param('documentnumber', PARAM_TEXT);
+    } else if ($method === 'pse') {
+        $formdata->psebank = required_param('psebank', PARAM_ALPHANUMEXT);
+        $formdata->usertype = required_param('usertype', PARAM_ALPHA);
+        $formdata->documenttype = required_param('documenttype', PARAM_ALPHANUMEXT);
+        $formdata->documentnumber = required_param('documentnumber', PARAM_TEXT);
+        $formdata->phone = required_param('phone', PARAM_TEXT);
+    } else if ($method === 'nequi' || $method === 'bancolombia') {
+        $formdata->phone = required_param('phone', PARAM_TEXT);
+        $formdata->documentnumber = required_param('documentnumber', PARAM_TEXT);
+    } else if ($method === 'googlepay') {
+        $formdata->gp_network = required_param('gp_network', PARAM_ALPHANUMEXT);
+        $formdata->gp_token = required_param('gp_token', PARAM_RAW);
+        $formdata->phone = required_param('phone', PARAM_TEXT);
+        $formdata->documentnumber = required_param('documentnumber', PARAM_TEXT);
+    } else if ($method === 'cash') {
+        $formdata->cashmethod = required_param('cashmethod', PARAM_ALPHANUMEXT);
+        $formdata->phone = required_param('phone', PARAM_TEXT);
+        $formdata->documentnumber = required_param('documentnumber', PARAM_TEXT);
+    }
+    $formdata->description = $description;
+    $formdata->email = $USER->email;
+    $response = api::submit_transaction($config, $paymentid, $amount, $currency, $formdata);
+    if ($response && strtoupper($response->state) === 'APPROVED') {
+        helper::deliver_order($component, $paymentarea, $itemid, $paymentid, $USER->id);
+        redirect(helper::get_success_url($component, $paymentarea, $itemid));
+    } else if ($response && !empty($response->extraParameters->BANK_URL)) {
+        redirect($response->extraParameters->BANK_URL);
+    } else if ($response && !empty($response->extraParameters->URL_PAYMENT_RECEIPT_HTML)) {
+        redirect($response->extraParameters->URL_PAYMENT_RECEIPT_HTML);
+    } else if ($response) {
+        throw new moodle_exception('paymentpending', 'paygw_payu');
+    } else {
+        throw new moodle_exception('paymenterror', 'paygw_payu');
+    }
+}
+
+$PAGE->set_url(new moodle_url('/payment/gateway/payu/pay.php'));
+$PAGE->set_context(context_system::instance());
+$PAGE->set_title(get_string('gatewayname', 'paygw_payu'));
+$PAGE->set_heading(get_string('gatewayname', 'paygw_payu'));
+
+$banks = api::get_pse_banks($config);
+$banklist = [];
+foreach ($banks as $code => $name) {
+    $banklist[] = ['code' => $code, 'name' => $name];
+}
+
+$templatecontext = [
+    'url' => (new moodle_url('/payment/gateway/payu/pay.php'))->__toString(),
+    'sesskey' => sesskey(),
+    'component' => $component,
+    'paymentarea' => $paymentarea,
+    'itemid' => $itemid,
+    'description' => $description,
+    'banks' => $banklist,
+];
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('gatewayname', 'paygw_payu'), 3);
+echo $OUTPUT->render_from_template('paygw_payu/checkout', $templatecontext);
+echo $OUTPUT->footer();
+

--- a/payment/gateway/payu/return.php
+++ b/payment/gateway/payu/return.php
@@ -1,0 +1,27 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Handles the browser return from PayU.
+ *
+ * @package     paygw_payu
+ * @copyright   2024 Example
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require(__DIR__ . '/../../../config.php');
+
+echo get_string('payment', 'paygw_payu');

--- a/payment/gateway/payu/settings.php
+++ b/payment/gateway/payu/settings.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Settings for the PayU Colombia payment gateway
+ *
+ * @package     paygw_payu
+ * @copyright   2024 Example
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+if ($ADMIN->fulltree) {
+    $settings->add(new admin_setting_heading('paygw_payu_settings', '', get_string('pluginname_desc', 'paygw_payu')));
+
+    \core_payment\helper::add_common_gateway_settings($settings, 'paygw_payu');
+}

--- a/payment/gateway/payu/templates/bancolombia.mustache
+++ b/payment/gateway/payu/templates/bancolombia.mustache
@@ -1,0 +1,11 @@
+{{!
+    Bancolombia button fields for PayU checkout.
+}}
+<div class="mb-3">
+    <label for="phone">{{# str }} phone, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="phone" id="phone" />
+</div>
+<div class="mb-3">
+    <label for="bancolombiadocument">{{# str }} documentnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="documentnumber" id="bancolombiadocument" />
+</div>

--- a/payment/gateway/payu/templates/cash.mustache
+++ b/payment/gateway/payu/templates/cash.mustache
@@ -1,0 +1,19 @@
+{{!
+    Cash payment options for PayU checkout.
+}}
+<div class="mb-3">
+    <label for="cashmethod">{{# str }} cashmethod, paygw_payu {{/ str }}</label>
+    <select name="cashmethod" id="cashmethod" class="form-select">
+        <option value="EFECTY">{{# str }} efecty, paygw_payu {{/ str }}</option>
+        <option value="OTHERS_CASH">{{# str }} otherscash, paygw_payu {{/ str }}</option>
+        <option value="BANK_REFERENCED">{{# str }} bankreferenced, paygw_payu {{/ str }}</option>
+    </select>
+</div>
+<div class="mb-3">
+    <label for="phone">{{# str }} phone, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="phone" id="phone" />
+</div>
+<div class="mb-3">
+    <label for="cashdocument">{{# str }} documentnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="documentnumber" id="cashdocument" />
+</div>

--- a/payment/gateway/payu/templates/checkout.mustache
+++ b/payment/gateway/payu/templates/checkout.mustache
@@ -1,0 +1,62 @@
+{{!
+    Template for PayU checkout form with multiple payment methods.
+}}
+<form method="post" action="{{url}}" id="payu-checkout">
+    <input type="hidden" name="sesskey" value="{{sesskey}}">
+    <input type="hidden" name="component" value="{{component}}">
+    <input type="hidden" name="paymentarea" value="{{paymentarea}}">
+    <input type="hidden" name="itemid" value="{{itemid}}">
+    <input type="hidden" name="description" value="{{description}}">
+
+    <div class="mb-3">
+        <label for="cardholder">{{# str }} cardholder, paygw_payu {{/ str }}</label>
+        <input type="text" class="form-control" name="cardholder" id="cardholder" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="paymentmethod">{{# str }} paymentmethod, paygw_payu {{/ str }}</label>
+        <select name="paymentmethod" id="paymentmethod" class="form-select">
+            <option value="creditcard">{{# str }} creditcard, paygw_payu {{/ str }}</option>
+            <option value="pse">{{# str }} pse, paygw_payu {{/ str }}</option>
+            <option value="nequi">{{# str }} nequi, paygw_payu {{/ str }}</option>
+            <option value="bancolombia">{{# str }} bancolombia, paygw_payu {{/ str }}</option>
+            <option value="googlepay">{{# str }} googlepay, paygw_payu {{/ str }}</option>
+            <option value="cash">{{# str }} cash, paygw_payu {{/ str }}</option>
+        </select>
+    </div>
+
+    <div class="payu-method-block" data-method="creditcard">
+        {{> paygw_payu/creditcard }}
+    </div>
+    <div class="payu-method-block" data-method="pse">
+        {{> paygw_payu/pse }}
+    </div>
+    <div class="payu-method-block" data-method="nequi">
+        {{> paygw_payu/nequi }}
+    </div>
+    <div class="payu-method-block" data-method="bancolombia">
+        {{> paygw_payu/bancolombia }}
+    </div>
+    <div class="payu-method-block" data-method="googlepay">
+        {{> paygw_payu/googlepay }}
+    </div>
+    <div class="payu-method-block" data-method="cash">
+        {{> paygw_payu/cash }}
+    </div>
+
+    <div class="mt-3">
+        <button type="submit" class="btn btn-primary">{{# str }} submitpayment, paygw_payu {{/ str }}</button>
+    </div>
+</form>
+
+{{#js}}
+require(['jquery'], function($) {
+    function toggle() {
+        var method = $('#paymentmethod').val();
+        $('.payu-method-block').hide();
+        $('.payu-method-block[data-method="' + method + '"]').show();
+    }
+    $(document).on('change', '#paymentmethod', toggle);
+    toggle();
+});
+{{/js}}

--- a/payment/gateway/payu/templates/creditcard.mustache
+++ b/payment/gateway/payu/templates/creditcard.mustache
@@ -1,0 +1,36 @@
+{{!
+    Credit card fields for PayU checkout.
+}}
+<div class="mb-3">
+    <label for="ccnumber">{{# str }} cardnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="ccnumber" id="ccnumber" />
+</div>
+<div class="mb-3">
+    <label for="ccexpmonth">{{# str }} expmonth, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="ccexpmonth" id="ccexpmonth" />
+</div>
+<div class="mb-3">
+    <label for="ccexpyear">{{# str }} expyear, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="ccexpyear" id="ccexpyear" />
+</div>
+<div class="mb-3">
+    <label for="cvv">{{# str }} cvv, paygw_payu {{/ str }}</label>
+    <input type="password" class="form-control" name="cvv" id="cvv" />
+</div>
+<div class="mb-3">
+    <label for="cardnetwork">{{# str }} cardnetwork, paygw_payu {{/ str }}</label>
+    <select class="form-select" name="cardnetwork" id="cardnetwork">
+        <option value="VISA">Visa</option>
+        <option value="MASTERCARD">Mastercard</option>
+        <option value="AMEX">AMEX</option>
+        <option value="DINERS">Diners</option>
+    </select>
+</div>
+<div class="mb-3">
+    <label for="ccphone">{{# str }} phone, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="phone" id="ccphone" />
+</div>
+<div class="mb-3">
+    <label for="ccdocumentnumber">{{# str }} documentnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="documentnumber" id="ccdocumentnumber" />
+</div>

--- a/payment/gateway/payu/templates/googlepay.mustache
+++ b/payment/gateway/payu/templates/googlepay.mustache
@@ -1,0 +1,24 @@
+{{!
+    Google Pay fields for PayU checkout.
+}}
+<div class="mb-3">
+    <label for="gp-network">{{# str }} cardnetwork, paygw_payu {{/ str }}</label>
+    <select name="gp_network" id="gp-network" class="form-select">
+        <option value="VISA">VISA</option>
+        <option value="MASTERCARD">MASTERCARD</option>
+        <option value="ELECTRON">ELECTRON</option>
+        <option value="MAESTRO">MAESTRO</option>
+    </select>
+</div>
+<div class="mb-3">
+    <label for="gp-token">{{# str }} googlepaytoken, paygw_payu {{/ str }}</label>
+    <textarea class="form-control" name="gp_token" id="gp-token" rows="4"></textarea>
+</div>
+<div class="mb-3">
+    <label for="gp-phone">{{# str }} phone, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="phone" id="gp-phone" />
+</div>
+<div class="mb-3">
+    <label for="gp-document">{{# str }} documentnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="documentnumber" id="gp-document" />
+</div>

--- a/payment/gateway/payu/templates/nequi.mustache
+++ b/payment/gateway/payu/templates/nequi.mustache
@@ -1,0 +1,11 @@
+{{!
+    Nequi phone field for PayU checkout.
+}}
+<div class="mb-3">
+    <label for="phone">{{# str }} phone, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="phone" id="phone" />
+</div>
+<div class="mb-3">
+    <label for="nequidocument">{{# str }} documentnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="documentnumber" id="nequidocument" />
+</div>

--- a/payment/gateway/payu/templates/pse.mustache
+++ b/payment/gateway/payu/templates/pse.mustache
@@ -1,0 +1,38 @@
+{{!
+    PSE bank transfer fields for PayU checkout.
+}}
+<div class="mb-3">
+    <label for="psebank">{{# str }} psebank, paygw_payu {{/ str }}</label>
+    <select name="psebank" id="psebank" class="form-select">
+        {{#banks}}
+        <option value="{{code}}">{{name}}</option>
+        {{/banks}}
+    </select>
+</div>
+<div class="mb-3">
+    <label for="usertype">{{# str }} usertype, paygw_payu {{/ str }}</label>
+    <select name="usertype" id="usertype" class="form-select">
+        <option value="N">{{# str }} personnatural, paygw_payu {{/ str }}</option>
+        <option value="J">{{# str }} personjuridica, paygw_payu {{/ str }}</option>
+    </select>
+</div>
+<div class="mb-3">
+    <label for="documenttype">{{# str }} documenttype, paygw_payu {{/ str }}</label>
+    <select name="documenttype" id="documenttype" class="form-select">
+        <option value="CC">CC</option>
+        <option value="CE">CE</option>
+        <option value="NIT">NIT</option>
+        <option value="TI">TI</option>
+        <option value="PP">PP</option>
+        <option value="RC">RC</option>
+        <option value="DE">DE</option>
+    </select>
+</div>
+<div class="mb-3">
+    <label for="documentnumber">{{# str }} documentnumber, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="documentnumber" id="documentnumber" />
+</div>
+<div class="mb-3">
+    <label for="phone">{{# str }} phone, paygw_payu {{/ str }}</label>
+    <input type="text" class="form-control" name="phone" id="phone" />
+</div>

--- a/payment/gateway/payu/version.php
+++ b/payment/gateway/payu/version.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Plugin version and other meta-data are defined here.
+ *
+ * @package     paygw_payu
+ * @copyright   2024 Example
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version   = 2024081608; // YYYYMMDDHH.
+$plugin->requires  = 2023100900; // Requires Moodle 4.3 or later.
+$plugin->component = 'paygw_payu';
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->release   = '0.1';


### PR DESCRIPTION
## Summary
- Send buyer, shipping and billing address information with each PayU transaction
- Include client IP as PSE_REFERENCE1 to complete PSE transfer parameters
- Collect document and phone fields for all methods and set cash expiration
- Bump plugin version for the finished PayU Colombia implementation

## Testing
- `php -l payment/gateway/payu/classes/api.php`
- `php -l payment/gateway/payu/pay.php`
- `vendor/bin/phpunit payment/gateway/payu/tests` *(fails: No such file or directory)*
- `phpunit payment/gateway/payu/tests` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ffee0ed20832a96e9cb08050928f7