### PR TITLE
Handle missing BUTTON_SUCCESS constant

### DIFF
--- a/local/downloadcenter/index.php
+++ b/local/downloadcenter/index.php
@@ -483,11 +483,15 @@ if (!empty($catids)) {
         // Botones de acción.
         echo html_writer::start_div('btn-group');
 
+        $downloadbuttontype = defined('single_button::BUTTON_SUCCESS')
+            ? single_button::BUTTON_SUCCESS
+            : single_button::BUTTON_PRIMARY;
+
         $downloadbutton = new single_button(
             local_downloadcenter_build_url([], ['action' => 'download']),
             get_string('downloadselection', 'local_downloadcenter'),
             'post',
-            single_button::BUTTON_SUCCESS
+            $downloadbuttontype
         );
         $downloadbutton->class .= ' mr-2';
         echo $OUTPUT->render($downloadbutton);


### PR DESCRIPTION
## Summary
- avoid using single_button::BUTTON_SUCCESS when constant is undefined
- fall back to BUTTON_PRIMARY for broader compatibility

## Testing
- ⚠️ `vendor/bin/phpunit local/downloadcenter/tests/files_visible_test.php` (missing: No such file or directory)
- ✅ `php -l local/downloadcenter/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68abe8361624832a9b3a0af8d9d8717f