### PR TITLE
Fix PayU gateway configuration field conflict

### DIFF
--- a/payment/gateway/payu/classes/api.php
+++ b/payment/gateway/payu/classes/api.php
@@ -159,7 +159,7 @@ class api {
             'test' => !empty($this->config->testmode),
             'transaction' => [
                 'order' => [
-                    'accountId' => $this->config->accountid,
+                    'accountId' => $this->config->payuaccountid,
                     'referenceCode' => (string)$paymentid,
                     'description' => substr($data->description ?? '', 0, 255),
                     'language' => 'es',

--- a/payment/gateway/payu/classes/gateway.php
+++ b/payment/gateway/payu/classes/gateway.php
@@ -59,10 +59,10 @@ class gateway extends \core_payment\gateway {
         $mform->addHelpButton('merchantid', 'merchantid', 'paygw_payu');
 
         // Account ID field.
-        $mform->addElement('text', 'accountid', get_string('accountid', 'paygw_payu'));
-        $mform->setType('accountid', PARAM_TEXT);
-        $mform->addRule('accountid', get_string('required'), 'required', null, 'client');
-        $mform->addHelpButton('accountid', 'accountid', 'paygw_payu');
+        $mform->addElement('text', 'payuaccountid', get_string('accountid', 'paygw_payu'));
+        $mform->setType('payuaccountid', PARAM_TEXT);
+        $mform->addRule('payuaccountid', get_string('required'), 'required', null, 'client');
+        $mform->addHelpButton('payuaccountid', 'accountid', 'paygw_payu');
 
         // API Login field.
         $mform->addElement('text', 'apilogin', get_string('apilogin', 'paygw_payu'));
@@ -132,8 +132,8 @@ class gateway extends \core_payment\gateway {
      * @param array $errors
      */
     public static function validate_gateway_form(account_gateway $form, \stdClass $data, array $files, array &$errors): void {
-        if ($data->enabled && 
-            (empty($data->merchantid) || empty($data->accountid) || 
+        if ($data->enabled &&
+            (empty($data->merchantid) || empty($data->payuaccountid) ||
              empty($data->apilogin) || empty($data->apikey))) {
             $errors['enabled'] = get_string('gatewaycannotbeenabled', 'payment');
         }
@@ -144,8 +144,8 @@ class gateway extends \core_payment\gateway {
         }
 
         // Validate account ID format (numeric).
-        if (!empty($data->accountid) && !is_numeric($data->accountid)) {
-            $errors['accountid'] = get_string('accountidinvalid', 'paygw_payu');
+        if (!empty($data->payuaccountid) && !is_numeric($data->payuaccountid)) {
+            $errors['payuaccountid'] = get_string('accountidinvalid', 'paygw_payu');
         }
 
         // Check that at least one payment method is enabled.

--- a/payment/gateway/payu/pay.php
+++ b/payment/gateway/payu/pay.php
@@ -46,7 +46,7 @@ $description = clean_param($description, PARAM_TEXT);
 $config = (object) helper::get_gateway_configuration($component, $paymentarea, $itemid, 'payu');
 
 // Check if gateway is configured.
-if (empty($config->merchantid) || empty($config->accountid) || 
+if (empty($config->merchantid) || empty($config->payuaccountid) ||
     empty($config->apilogin) || empty($config->apikey)) {
     throw new moodle_exception('gatewaynotconfigured', 'paygw_payu');
 }


### PR DESCRIPTION
## Summary
- Avoid duplicated `accountid` form field by using a unique `payuaccountid` configuration key in PayU gateway
- Read `payuaccountid` throughout PayU payment code and API requests

## Testing
- `php -l payment/gateway/payu/classes/api.php`
- `php -l payment/gateway/payu/classes/gateway.php`
- `php -l payment/gateway/payu/pay.php`
- `vendor/bin/phpunit payment/tests/helper_test.php` *(fails: missing config.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3fad9004832aa12a4e2ce51dd071