### PR TITLE
feat(rolestyles): hide non-submitters for assignments

### DIFF
--- a/local/rolestyles/assets/filter.js
+++ b/local/rolestyles/assets/filter.js
@@ -1,0 +1,38 @@
+/**
+ * Filter out participants without submissions on grading pages when a selected role is active.
+ *
+ * @package    local_rolestyles
+ */
+(function() {
+    'use strict';
+
+    function hasSelectedRole() {
+        return Array.prototype.some.call(document.body.classList, function(cls) {
+            return cls.indexOf('roleid-') === 0;
+        });
+    }
+
+    function filterAssignTable() {
+        var table = document.querySelector('#submissions');
+        if (!table) {
+            return;
+        }
+        table.querySelectorAll('tbody tr').forEach(function(row) {
+            var status = row.querySelector('div.submissionstatus');
+            if (status && /no submission/i.test(status.textContent)) {
+                row.style.display = 'none';
+            }
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        if (!hasSelectedRole()) {
+            return;
+        }
+        var url = window.location.pathname + window.location.search;
+        if (url.indexOf('/mod/assign/view.php') !== -1 && url.indexOf('action=grading') !== -1) {
+            filterAssignTable();
+        }
+    });
+})();
+

--- a/local/rolestyles/lib.php
+++ b/local/rolestyles/lib.php
@@ -87,6 +87,9 @@ function local_rolestyles_inject_css() {
         foreach ($role_classes as $class) {
             $PAGE->add_body_class($class);
         }
+
+        // Load filtering script to hide participants without submissions on grading pages.
+        $PAGE->requires->js(new moodle_url('/local/rolestyles/assets/filter.js'));
         
         // Get custom CSS
         $custom_css = get_config('local_rolestyles', 'custom_css');


### PR DESCRIPTION
## Summary
- load a lightweight script when role styles are active
- script hides assignment grading rows with "no submission"

## Testing
- `php -l local/rolestyles/lib.php`
- `node --check local/rolestyles/assets/filter.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6d32b6fd8832a8dd21332165f4da2