### PR TITLE
feat(local_rolestyles): filter ungraded submissions by role

### DIFF
--- a/local/rolestyles/assets/filter.js
+++ b/local/rolestyles/assets/filter.js
@@ -1,5 +1,6 @@
 /**
- * Filter out participants without submissions on grading pages when a selected role is active.
+ * Filter out participants without submissions or with graded submissions on grading pages when a selected role is active.
+ * Provides a visual indicator with counters for visible and hidden participants.
  *
  * @package    local_rolestyles
  */
@@ -17,31 +18,71 @@
     }
 
     /**
-     * Hide table rows whose status text matches any of the supplied patterns.
+     * Hide table rows according to submission and grading patterns.
      *
      * @param {string} tableSelector selector for the table element
      * @param {string|null} statusSelector selector for the element containing submission status
-     * @param {Array<RegExp>} patterns regular expressions indicating missing submissions
+     * @param {Array<RegExp>} statusPatterns regular expressions indicating missing submissions
+     * @param {string|null} gradeSelector selector for the element containing grade information
+     * @param {Array<RegExp>} gradePatterns regular expressions indicating graded submissions
+     * @return {Object} summary with total/visible/hidden counts
      */
-    function hideRows(tableSelector, statusSelector, patterns) {
+    function hideRows(tableSelector, statusSelector, statusPatterns, gradeSelector, gradePatterns) {
         var table = document.querySelector(tableSelector);
         if (!table) {
+            return {total: 0, visible: 0, hidden: 0};
+        }
+        var total = 0, visible = 0, hidden = 0;
+        table.querySelectorAll('tbody tr').forEach(function(row) {
+            total++;
+            var hide = false;
+            if (statusSelector) {
+                var statusNode = row.querySelector(statusSelector);
+                var statusText = statusNode ? statusNode.textContent : '';
+                statusPatterns.some(function(pattern) {
+                    if (pattern.test(statusText)) {
+                        hide = true;
+                        return true;
+                    }
+                    return false;
+                });
+            }
+            if (!hide && gradeSelector) {
+                var gradeNode = row.querySelector(gradeSelector);
+                var gradeText = gradeNode ? gradeNode.textContent : '';
+                gradePatterns.some(function(pattern) {
+                    if (pattern.test(gradeText)) {
+                        hide = true;
+                        return true;
+                    }
+                    return false;
+                });
+            }
+            if (hide) {
+                row.style.display = 'none';
+                hidden++;
+            } else {
+                visible++;
+            }
+        });
+        return {total: total, visible: visible, hidden: hidden};
+    }
+
+    /**
+     * Display a visual indicator summarising the filtering results.
+     *
+     * @param {Object} summary counts object
+     */
+    function showIndicator(summary) {
+        if (!summary || summary.hidden === 0) {
             return;
         }
-        table.querySelectorAll('tbody tr').forEach(function(row) {
-            var target = statusSelector ? row.querySelector(statusSelector) : row;
-            if (!target) {
-                return;
-            }
-            var text = target.textContent || '';
-            patterns.some(function(pattern) {
-                if (pattern.test(text)) {
-                    row.style.display = 'none';
-                    return true;
-                }
-                return false;
-            });
-        });
+        var container = document.querySelector('div[role="main"]') || document.body;
+        var message = M.util.get_string('filterindicator', 'local_rolestyles', summary);
+        var indicator = document.createElement('div');
+        indicator.className = 'alert alert-info rolestyles-filter-indicator';
+        indicator.textContent = message;
+        container.insertBefore(indicator, container.firstChild);
     }
 
     /**
@@ -51,28 +92,39 @@
         if (!hasSelectedRole()) {
             return;
         }
-
         var url = window.location.pathname + window.location.search;
+        var summary = {total: 0, visible: 0, hidden: 0};
+        var result;
 
         // Assignment grading page.
         if (url.indexOf('/mod/assign/view.php') !== -1 && url.indexOf('action=grading') !== -1) {
-            hideRows('#submissions', 'div.submissionstatus', [/no submission/i, /sin entrega/i]);
+            result = hideRows('#submissions', 'div.submissionstatus', [/no submission/i, /sin entrega/i],
+                'div.gradingstatus', [/graded/i, /calificado/i]);
+            summary.total += result.total; summary.visible += result.visible; summary.hidden += result.hidden;
         }
 
         // Quiz reports and grading pages.
         if (url.indexOf('/mod/quiz/report.php') !== -1) {
-            hideRows('#attempts, #attemptsform', null, [/no attempt/i, /not yet started/i, /sin intento/i]);
+            result = hideRows('#attempts, #attemptsform', null, [/no attempt/i, /not yet started/i, /sin intento/i],
+                'td.grade, td.lastcol', [/\d/, /graded/i, /calificado/i]);
+            summary.total += result.total; summary.visible += result.visible; summary.hidden += result.hidden;
         }
 
         // Forum grading interface.
         if (url.indexOf('/mod/forum') !== -1 && url.indexOf('grading') !== -1) {
-            hideRows('table', null, [/no posts/i, /sin participaci/i]);
+            result = hideRows('table', null, [/no posts/i, /sin participaci/i],
+                'td.score, td.lastcol', [/\d/, /graded/i, /calificado/i]);
+            summary.total += result.total; summary.visible += result.visible; summary.hidden += result.hidden;
         }
 
         // Workshop submission management.
         if (url.indexOf('/mod/workshop') !== -1 && url.indexOf('submissions') !== -1) {
-            hideRows('#submissions', null, [/not submitted/i, /sin env[íi]o/i]);
+            result = hideRows('#submissions', null, [/not submitted/i, /sin env[íi]o/i],
+                'td.grade, td.lastcol', [/\d/, /graded/i, /calificado/i]);
+            summary.total += result.total; summary.visible += result.visible; summary.hidden += result.hidden;
         }
+
+        showIndicator(summary);
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/local/rolestyles/lang/en/local_rolestyles.php
+++ b/local/rolestyles/lang/en/local_rolestyles.php
@@ -76,6 +76,9 @@ $string['developer_info_desc'] = '<strong>This plugin has been created for anoth
 $string['role_styles_applied'] = 'Styles applied for roles: {$a}';
 $string['no_roles_found'] = 'No matching roles found for this user';
 
+// Filtering indicator
+$string['filterindicator'] = 'Role filter active: {$a->visible} of {$a->total} participants shown ({$a->hidden} hidden)';
+
 // Errors
 $string['error_no_roles_selected'] = 'No roles have been selected. Please select at least one role in settings.';
 $string['error_invalid_css'] = 'CSS contains elements not allowed for security reasons.';

--- a/local/rolestyles/lang/es/local_rolestyles.php
+++ b/local/rolestyles/lang/es/local_rolestyles.php
@@ -76,6 +76,9 @@ $string['developer_info_desc'] = '<strong>Este plugin ha sido creado para otro c
 $string['role_styles_applied'] = 'Estilos aplicados para los roles: {$a}';
 $string['no_roles_found'] = 'No se encontraron roles coincidentes para este usuario';
 
+// Indicador de filtrado
+$string['filterindicator'] = 'Filtro de rol activo: se muestran {$a->visible} de {$a->total} participantes ({$a->hidden} ocultos)';
+
 // Errores
 $string['error_no_roles_selected'] = 'No se han seleccionado roles. Por favor, selecciona al menos un rol en la configuración.';
 $string['error_invalid_css'] = 'El CSS contiene elementos no permitidos por seguridad.';


### PR DESCRIPTION
## Summary
- filter assignment grading table to show only ungraded submissions when role-based filtering is active with simple caching
- add client-side filtering for quiz, forum and workshop grading views with indicator and counters
- cache role checks and expose JS strings for indicator

## Testing
- `php -l local/rolestyles/lib.php`
- `php -l local/rolestyles/classes/output/assign_renderer.php`
- `php -l local/rolestyles/lang/en/local_rolestyles.php`
- `php -l local/rolestyles/lang/es/local_rolestyles.php`
- `npx eslint local/rolestyles/assets/filter.js` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f91debe4832a98497ba76dff0eaf