### PR TITLE
Refactor assign grading filter

### DIFF
--- a/local/rolestyles/classes/output/assign_renderer.php
+++ b/local/rolestyles/classes/output/assign_renderer.php
@@ -36,30 +36,7 @@ class assign_renderer extends assign_renderer_base {
             $pagesize = $table->get_rows_per_page();
             $table->setup();
 
-            // Cache filtered rows per assignment and page to avoid repeated DB queries.
-            $assignid = $table->assignment->get_instance()->id ?? 0;
-            $page = property_exists($table, 'currpage') ? $table->currpage : 0;
-            static $cache = [];
-            $cachekey = $assignid . ':' . $page;
-
-            if (!array_key_exists($cachekey, $cache)) {
-                $table->query_db($pagesize, false);
-                $allrows = $table->rawdata ?? [];
-                if (!empty($allrows)) {
-                    $filtered = array_filter($allrows, function($row) {
-                        return $row->status !== ASSIGN_SUBMISSION_STATUS_NEW && $row->grade === null;
-                    });
-                } else {
-                    $filtered = [];
-                }
-                $cache[$cachekey] = ['filtered' => $filtered, 'total' => count($allrows)];
-            } else {
-                // Ensure pagination setup.
-                $table->query_db($pagesize, false);
-            }
-
-            $filtered = $cache[$cachekey]['filtered'];
-            $total = $cache[$cachekey]['total'];
+            [$filtered, $total] = \local_rolestyles_filter_assign_grading($table, $pagesize);
             $visible = count($filtered);
 
             $table->rawdata = $filtered;
@@ -70,7 +47,7 @@ class assign_renderer extends assign_renderer_base {
             $summary = \local_rolestyles_get_filter_summary($total, $visible);
             $o .= $this->output->notification($summary, 'info');
             $o .= $this->output->box_start('boxaligncenter gradingtable position-relative');
-            $this->page->requires->js_init_call('M.mod_assign.init_grading_table', array());
+            $this->page->requires->js_init_call('M.mod_assign.init_grading_table', []);
             ob_start();
             $table->finish_output();
             $o .= ob_get_clean();


### PR DESCRIPTION
## Summary
- Refactor mod_assign grading renderer to use reusable server-side filtering helper
- Add cached helper to hide participants without submissions or with graded work

## Testing
- `php -l local/rolestyles/lib.php`
- `php -l local/rolestyles/classes/output/assign_renderer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b75d8a7a0c832aba6496f3fc7f6dfa