### PR TITLE
Refactor assign grading filter

### DIFF
--- a/local/rolestyles/classes/output/assign_renderer.php
+++ b/local/rolestyles/classes/output/assign_renderer.php
@@ -33,33 +33,9 @@ class assign_renderer extends assign_renderer_base {
      */
     public function render_assign_grading_table(assign_grading_table $table) {
         if (\local_rolestyles_has_selected_role()) {
-            $pagesize = $table->get_rows_per_page();
             $table->setup();
 
-            // Cache filtered rows per assignment and page to avoid repeated DB queries.
-            $assignid = $table->assignment->get_instance()->id ?? 0;
-            $page = property_exists($table, 'currpage') ? $table->currpage : 0;
-            static $cache = [];
-            $cachekey = $assignid . ':' . $page;
-
-            if (!array_key_exists($cachekey, $cache)) {
-                $table->query_db($pagesize, false);
-                $allrows = $table->rawdata ?? [];
-                if (!empty($allrows)) {
-                    $filtered = array_filter($allrows, function($row) {
-                        return $row->status !== ASSIGN_SUBMISSION_STATUS_NEW && $row->grade === null;
-                    });
-                } else {
-                    $filtered = [];
-                }
-                $cache[$cachekey] = ['filtered' => $filtered, 'total' => count($allrows)];
-            } else {
-                // Ensure pagination setup.
-                $table->query_db($pagesize, false);
-            }
-
-            $filtered = $cache[$cachekey]['filtered'];
-            $total = $cache[$cachekey]['total'];
+            [$filtered, $total] = \local_rolestyles_filter_assign_grading($table);
             $visible = count($filtered);
 
             $table->rawdata = $filtered;
@@ -70,7 +46,7 @@ class assign_renderer extends assign_renderer_base {
             $summary = \local_rolestyles_get_filter_summary($total, $visible);
             $o .= $this->output->notification($summary, 'info');
             $o .= $this->output->box_start('boxaligncenter gradingtable position-relative');
-            $this->page->requires->js_init_call('M.mod_assign.init_grading_table', array());
+            $this->page->requires->js_init_call('M.mod_assign.init_grading_table', []);
             ob_start();
             $table->finish_output();
             $o .= ob_get_clean();

--- a/local/rolestyles/db/hooks.php
+++ b/local/rolestyles/db/hooks.php
@@ -20,16 +20,9 @@ defined('MOODLE_INTERNAL') || die();
 $hooks = [
     // Nuevo hook system para Moodle 4.0+
     [
-        'callback' => 'local_rolestyles_before_http_headers',
-        'hookname' => 'core\hook\output\before_http_headers',
+        'callback' => 'local_rolestyles_hook_before_http_headers',
+        'hookname' => 'core\\hook\\output\\before_http_headers',
         'priority' => 100,
     ],
 ];
 
-// Callbacks legacy para versiones anteriores de Moodle
-$callbacks = [
-    [
-        'file' => 'local/rolestyles/lib.php',
-        'function' => 'local_rolestyles_before_http_headers'
-    ]
-];

--- a/local/rolestyles/lib.php
+++ b/local/rolestyles/lib.php
@@ -19,7 +19,7 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Hook implementation for Moodle 4.0+
  */
-function local_rolestyles_before_http_headers($hook = null): void {
+function local_rolestyles_hook_before_http_headers($hook = null): void {
     global $PAGE, $CFG;
     local_rolestyles_inject_css();
     if (local_rolestyles_has_selected_role()) {
@@ -27,13 +27,6 @@ function local_rolestyles_before_http_headers($hook = null): void {
         // Register custom renderer factory for this request when a role is active.
         $PAGE->theme->rendererfactory = \local_rolestyles\assign_renderer_factory::class;
     }
-}
-
-/**
- * Legacy callback for earlier versions
- */
-function local_rolestyles_before_http_headers_callback() {
-    local_rolestyles_before_http_headers();
 }
 
 /**
@@ -195,6 +188,37 @@ function local_rolestyles_get_filter_summary(int $total, int $visible): string {
         'hidden' => $hidden,
     ];
     return get_string('filtersummary', 'local_rolestyles', $data);
+}
+
+/**
+ * Filter assignment grading table rows to include only submitted and ungraded participants.
+ *
+ * This helper centralises the logic used by the custom assign renderer and provides
+ * a basic in-memory cache to avoid repeating the same database query within a request.
+ *
+ * @param assign_grading_table $table The grading table instance.
+ * @param int $pagesize Number of rows per page.
+ * @return array Array containing the filtered rows and the total rows count.
+ */
+function local_rolestyles_filter_assign_grading(assign_grading_table $table): array {
+    $assignid = $table->assignment->get_instance()->id ?? 0;
+    $page = property_exists($table, 'currpage') ? $table->currpage : 0;
+    static $cache = [];
+    $cachekey = $assignid . ':' . $page;
+
+    if (!isset($cache[$cachekey])) {
+        $rows = $table->rawdata ?? [];
+        if (!empty($rows)) {
+            $filtered = array_filter($rows, static function($row) {
+                return !empty($row->status) && $row->status !== ASSIGN_SUBMISSION_STATUS_NEW && $row->grade === null;
+            });
+        } else {
+            $filtered = [];
+        }
+        $cache[$cachekey] = ['rows' => $filtered, 'total' => is_array($rows) ? count($rows) : 0];
+    }
+
+    return [$cache[$cachekey]['rows'], $cache[$cachekey]['total']];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Refactor mod_assign grading renderer to use reusable server-side filtering helper
- Add cached helper to hide participants without submissions or with graded work
- Migrate local_rolestyles plugin to new before_http_headers hook and solidify ungraded submission filtering

## Testing
- `php -l local/rolestyles/classes/output/assign_renderer.php`
- `php -l local/rolestyles/lib.php`


------
https://chatgpt.com/codex/tasks/task_e_68b75d8a7a0c832aba6496f3fc7f6dfa