### PR TITLE
Filter assignment grading table for selected roles

### DIFF
--- a/local/rolestyles/classes/assign_filter.php
+++ b/local/rolestyles/classes/assign_filter.php
@@ -56,7 +56,7 @@ class assign_filter {
     }
 
     /**
-     * Filter rows without submissions.
+     * Filter rows to only include participants with submitted work.
      *
      * @param assign_grading_table $table
      * @return array [filtered rows, total rows]
@@ -69,7 +69,7 @@ class assign_filter {
         $total = count($rows);
         $filtered = array_filter($rows, static function($row) {
             $status = $row->status ?? '';
-            return $status !== '' && $status !== ASSIGN_SUBMISSION_STATUS_NEW;
+            return $status === ASSIGN_SUBMISSION_STATUS_SUBMITTED;
         });
         return [array_values($filtered), $total];
     }


### PR DESCRIPTION
## Summary
- Show only students with submitted work in assignment grading table for users with configured roles

## Testing
- `php -l local/rolestyles/classes/assign_filter.php`
- `phpunit mod/assign/tests/lib_test.php` *(fails: config.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9efb917d0832aaeb82612282d02e2