### PR TITLE
Filter assignment grading table for selected roles

### DIFF
--- a/local/rolestyles/classes/assign_filter.php
+++ b/local/rolestyles/classes/assign_filter.php
@@ -56,7 +56,7 @@ class assign_filter {
     }
 
     /**
-     * Filter rows without submissions.
+     * Filter rows to only include participants with submitted work.
      *
      * @param assign_grading_table $table
      * @return array [filtered rows, total rows]
@@ -69,7 +69,7 @@ class assign_filter {
         $total = count($rows);
         $filtered = array_filter($rows, static function($row) {
             $status = $row->status ?? '';
-            return $status !== '' && $status !== ASSIGN_SUBMISSION_STATUS_NEW;
+            return $status === ASSIGN_SUBMISSION_STATUS_SUBMITTED;
         });
         return [array_values($filtered), $total];
     }

--- a/local/rolestyles/db/hooks.php
+++ b/local/rolestyles/db/hooks.php
@@ -16,11 +16,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $hooks = [
     [
-        'hookname' => 'core\\hook\\after_config',
-        'callback' => 'local_rolestyles_after_config',
-        'priority' => 100,
-    ],
-    [
         'hookname' => 'core\\hook\\output\\before_http_headers',
         'callback' => 'local_rolestyles_hook_before_http_headers',
         'priority' => 100,

--- a/local/rolestyles/lib.php
+++ b/local/rolestyles/lib.php
@@ -29,9 +29,16 @@ function local_rolestyles_hook_before_http_headers($hook = null): void {
 }
 
 /**
- * Early hook to register the custom renderer factory.
+ * Register the custom renderer factory after login is complete.
+ *
+ * @param mixed $courseorid Unused course identifier.
+ * @param mixed $autologinguest Unused guest flag.
+ * @param mixed $cm Unused course module.
+ * @param mixed $setwantsurltome Unused flag.
+ * @param mixed $preventredirect Unused flag.
  */
-function local_rolestyles_after_config(): void {
+function local_rolestyles_after_require_login($courseorid = null, $autologinguest = null, $cm = null,
+        $setwantsurltome = null, $preventredirect = null): void {
     global $PAGE, $CFG;
 
     if (!get_config('local_rolestyles', 'enabled')) {


### PR DESCRIPTION
## Summary
- Show only students with submitted work in assignment grading table for users with configured roles
- Register renderer factory after login to avoid early theme initialization errors

## Testing
- `php -l local/rolestyles/lib.php`
- `php -l local/rolestyles/db/hooks.php`
- `php -l local/rolestyles/classes/assign_filter.php`
- `php -l local/rolestyles/classes/output/assign_renderer.php`
- `composer install --no-interaction --no-progress --ignore-platform-req=ext-sodium`
- `vendor/bin/phpunit mod/assign/tests/lib_test.php` *(fails: config.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9efb917d0832aaeb82612282d02e2