### PR TITLE
Protect assign override against direct access

### DIFF
--- a/local/assignhideunsubmitted/classes/assign.php
+++ b/local/assignhideunsubmitted/classes/assign.php
@@ -24,6 +24,8 @@
 
 namespace local_assignhideunsubmitted;
 
+defined('MOODLE_INTERNAL') || die();
+
 class assign extends \assign {
     /**
      * Load a list of users enrolled in the current course with the specified permission and group.


### PR DESCRIPTION
## Summary
- Prevent direct web access to the assign override class used by `local_assignhideunsubmitted`
- Ensure existing logic still filters out users without submissions for selected roles

## Testing
- `php -l local/assignhideunsubmitted/classes/assign.php`
- `vendor/bin/phpunit mod/assign/tests/locallib_test.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fd1fb4e8832a8826ff99ee0a9dcc