### PR TITLE
feat: collapse course index and center quiz intro

### DIFF
--- a/theme/inteb/classes/coursehandler.php
+++ b/theme/inteb/classes/coursehandler.php
@@ -1,0 +1,186 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Course handler overrides for theme_inteb.
+ *
+ * Extends the RemUI course handler so that instructor details on
+ * course cards include both editing teachers and non‑editing teachers
+ * and exposes an instructorcount matching RemUI's implementation.
+ *
+ * @package   theme_inteb
+ * @copyright 2024
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use theme_remui\utility;
+
+require_once($CFG->dirroot . '/theme/remui/classes/coursehandler.php');
+
+class theme_inteb_coursehandler extends theme_remui_coursehandler {
+    /**
+     * Retrieve courses and inject instructor information for both
+     * editing teachers and teachers.
+     *
+     * @param int|bool $totalcount Return count only.
+     * @param string|null $search Search term.
+     * @param int|array|null $category Category filter.
+     * @param int $limitfrom Offset for paging.
+     * @param int $limitto Limit for paging.
+     * @param array|null $mycourses My courses filter.
+     * @param string|null $categorysort Sort order.
+     * @param array $courses Pre-fetched courses.
+     * @param bool $filtermodified Filter modified courses.
+     * @param array $filteredcourseids Filtered course IDs.
+     * @param bool $isfilterapplied Filter flag.
+     * @return array|int Courses array or total count.
+     */
+    public function get_courses(
+        $totalcount = false,
+        $search = null,
+        $category = null,
+        $limitfrom = 0,
+        $limitto = 0,
+        $mycourses = null,
+        $categorysort = null,
+        $courses = [],
+        $filtermodified = false,
+        $filteredcourseids = [],
+        $isfilterapplied = false
+    ) {
+        global $CFG, $DB;
+
+        $result = parent::get_courses(
+            $totalcount,
+            $search,
+            $category,
+            $limitfrom,
+            $limitto,
+            $mycourses,
+            $categorysort,
+            $courses,
+            $filtermodified,
+            $filteredcourseids,
+            $isfilterapplied
+        );
+
+        if ($totalcount !== false) {
+            // Parent returned array($coursecount, $coursesarray).
+            list($coursecount, $coursesarray) = $result;
+            $coursesarray = $this->append_instructors($coursesarray);
+            return [$coursecount, $coursesarray];
+        }
+
+        $coursesarray = $this->append_instructors($result);
+        return $coursesarray;
+    }
+
+    /**
+     * Append instructor and instructorcount fields to courses array.
+     *
+     * @param array $coursesarray Courses array from parent handler.
+     * @return array Modified courses array.
+     */
+    protected function append_instructors(array $coursesarray): array {
+        global $CFG, $DB;
+
+        foreach ($coursesarray as &$course) {
+            $context = \context_course::instance($course['courseid']);
+            $roles = $DB->get_records_list('role', 'shortname', ['editingteacher', 'teacher'], '', 'id');
+            $instructors = [];
+            foreach ($roles as $role) {
+                $users = get_role_users($role->id, $context, false, 'u.*');
+                foreach ($users as $user) {
+                    $instructors[$user->id] = $user; // Ensure uniqueness.
+                }
+            }
+            if ($instructors) {
+                $users = array_values($instructors);
+                $first = array_shift($users);
+                $course['instructor'] = [
+                    'name' => fullname($first, true),
+                    'url' => $CFG->wwwroot . '/user/profile.php?id=' . $first->id,
+                    'picture' => utility::get_user_picture($first),
+                    'imgStyle' => ''
+                ];
+                $course['instructorcount'] = count($users) ? count($users) : '';
+            } else {
+                $course['instructor'] = false;
+                $course['instructorcount'] = '';
+            }
+        }
+        unset($course);
+
+        return $coursesarray;
+    }
+
+    /**
+     * Get enrolled teachers (editing and non-editing) for templates.
+     *
+     * @param \stdClass $course Course object.
+     * @param bool $frontlineteacher Limit to frontline teachers.
+     * @return array Context containing instructor info.
+     */
+    public function get_enrolled_teachers_context($course, $frontlineteacher = false): array {
+        global $OUTPUT, $CFG, $USER, $DB;
+
+        $courseid = $course->id;
+
+        $usergroups = groups_get_user_groups($courseid, $USER->id);
+        $groupids = 0;
+        if ($course->groupmode == 1) {
+            $groupids = $usergroups[0];
+        }
+
+        $coursecontext = \context_course::instance($courseid);
+        $roles = $DB->get_records_list('role', 'shortname', ['editingteacher', 'teacher'], '', 'id');
+
+        $teachers = [];
+        foreach ($roles as $role) {
+            $users = get_role_users($role->id, $coursecontext, false, 'u.*', 'firstname', true, $groupids);
+            foreach ($users as $user) {
+                $teachers[$user->id] = $user;
+            }
+        }
+
+        $context = [];
+        if ($teachers) {
+            $namescount = 4;
+            $profilecount = 0;
+            foreach ($teachers as $teacher) {
+                if ($frontlineteacher && $profilecount < $namescount) {
+                    $instructor = [];
+                    $instructor['id'] = $teacher->id;
+                    $instructor['name'] = fullname($teacher, true);
+                    $instructor['avatars'] = $OUTPUT->user_picture($teacher);
+                    $instructor['teacherprofileurl'] = $CFG->wwwroot . '/user/profile.php?id=' . $teacher->id;
+                    if ($profilecount != 0) {
+                        $instructor['hasanother'] = true;
+                    }
+                    $context['instructors'][] = $instructor;
+                }
+                $profilecount++;
+            }
+            if ($profilecount > $namescount) {
+                $context['teachercount'] = $profilecount - $namescount;
+            }
+            $role = reset($roles);
+            $context['participantspageurl'] = $CFG->wwwroot . '/user/index.php?id=' . $courseid . '&roleid=' . $role->id;
+            $context['hasteachers'] = true;
+        }
+        return $context;
+    }
+}

--- a/theme/inteb/layout/common.php
+++ b/theme/inteb/layout/common.php
@@ -84,7 +84,7 @@ if (!$courseindex) {
 $extraclasses[] = \theme_remui\utility::get_main_bg_class();
 
 // Focus data.
-$coursehandler = new \theme_remui_coursehandler();
+$coursehandler = new \theme_inteb_coursehandler();
 $focusdata = $coursehandler->get_focus_context_data();
 if (isset($focusdata['on']) && $focusdata['on']) {
     $extraclasses[] = 'focusmode';

--- a/theme/inteb/scss/inteb.scss
+++ b/theme/inteb/scss/inteb.scss
@@ -605,6 +605,15 @@ a.nav-link {
     background-color: $color-primary;
     border-radius: 0;
     justify-content: space-between;
+
+    a {
+        color: #ffffff;
+
+        &:hover,
+        &:focus {
+            color: #ffffff;
+        }
+    }
 }
 #theme_remui-drawers-courseindex .drawercontent #courseindex #courseindex-content .courseindex .courseindex-section .courseindex-section-title .edw-icon, #theme_remui-drawers-courseindex .drawercontent #courseindex #courseindex-content .courseindex .courseindex-section .courseindex-section-title .fa-lock {
     font-size: 24px;
@@ -775,3 +784,72 @@ button.btn.btn-primary.icon-no-margin.p-0 {
 /* Para los teléfonos más pequeños */
 @media (max-width: 479px) {
 }
+
+/* Course index collapsed by default */
+#page-course-view .courseindex .courseindex-item-content {
+    display: none;
+}
+
+/* Centre quiz intro and start attempt button */
+#page-mod-quiz-view #intro,
+#page-mod-quiz-view .activity-description,
+#page-mod-quiz-view .quiz-info {
+    text-align: center;
+}
+
+#page-mod-quiz-view .tertiary-navigation .row {
+    justify-content: center;
+}
+
+#page-mod-quiz-view .quizstartbuttondiv {
+    text-align: center;
+}
+
+/* Course index item styling */
+/* Ensure text and icons remain visible on dark backgrounds */
+#theme_remui-drawers-courseindex .drawercontent #courseindex #courseindex-content .courseindex .courseindex-section .courseindex-item-content .courseindex-sectioncontent .courseindex-item,
+#theme_remui-drawers-courseindex .drawercontent #courseindex #courseindex-content .courseindex .courseindex-sectioncontent > .courseindex-item {
+    padding: 4px 24px;
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    border-radius: unset;
+    background-color: transparent;
+
+    .courseindex-link {
+        color: #fff;
+
+        &:hover,
+        &:focus {
+            color: #fff;
+        }
+    }
+
+    .edw-icon,
+    .fa-lock {
+        font-size: 18px;
+        height: 18px;
+        width: 18px;
+        color: #fff;
+    }
+
+    &:hover,
+    &:focus-within,
+    &[aria-selected="true"] {
+        background-color: $color-primary;
+        color: #fff;
+
+        .courseindex-link,
+        .edw-icon,
+        .fa-lock {
+            color: #fff;
+        }
+    }
+}
+
+/* Highlight selected course category */
+#course-category-listings .listitem[data-selected="1"] {
+    border-left: calc(1px + 5px) solid $color-primary;
+    padding-left: calc(1.25rem - 5px);
+}
+

--- a/theme/inteb/templates/core_course/coursecard.mustache
+++ b/theme/inteb/templates/core_course/coursecard.mustache
@@ -1,0 +1,107 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle. If not, see <http: //www.gnu.org/licenses />.
+
+    Edwiser RemUI
+    @package theme_remui
+    @copyright (c) 2023 WisdmLabs (https://wisdmlabs.com/)
+    @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+{{!
+    @template course_course/coursecard
+
+    This template renders the a card for the course cards.
+
+    Example context (json):
+    {
+        "courses": [{
+            "name": "Assignment due 1",
+            "viewurl": "https://moodlesite/course/view.php?id=2",
+            "courseimage": "https://moodlesite/pluginfile/123/course/overviewfiles/123.jpg",
+            "fullname": "course 3",
+            "hasprogress": true,
+            "progress": 10,
+            "visible": true
+        }]
+    }
+}}
+<div class="card dashboard-card edwanimate-{{cardanimation}} " role="listitem" data-region="course-content" data-course-id="{{{id}}}">
+    <div tabindex="-1">
+        <div class="card-img dashboard-card-img p-p-4 edw-course-img-wrapper"
+            style='background-image: url("{{#remuicourseimage}}{{remuicourseimage}}{{/remuicourseimage}}{{^remuicourseimage}}{{{courseimage}}}{{/remuicourseimage}}");'>
+            <a href="{{ viewurl }} " class="view-course-url"></a>
+            <div class="card-img-icons-wrapper d-flex align-items-center flex-gap-2 ml-auto">
+                {{> core_course/favouriteicon }}
+                {{^visible}}
+                <div class="visibilityicon">
+                    <span class="hidden-icon edw-icon edw-icon-Hide visible" aria-hidden="true"
+                        title="{{#str}} hiddencourse, theme_remui {{/str}}"></span>
+                </div>
+                {{/visible}}
+                {{$menu}}{{/menu}}
+                <span class="sr-only">{{#str}}aria:courseimage, theme_remui{{/str}}</span>
+            </div>
+        </div>
+    </div>
+    <div class="card-body course-info-container d-flex flex-column  justify-content-between  flex-gap-3"
+id="course-info-container-{{id}}-{{uniqid}}">
+        <div class="edw-card-design-hd d-flex flex-column flex-gap-3">
+            <div class="d-flex flex-column align-items-start flex-gap-3">
+                <!-- <div class="text-muted muted d-flex flex-wrap"> -->
+                    <span class="categoryname text-truncate small-info-semibold" title=" {{{coursecategory}}}">
+                        {{$coursecategory}}{{/coursecategory}}
+                    </span>
+                <!-- </div> -->
+                <div class="w-100 text-truncate">
+                    {{#showshortname}}
+                    <div class="text-muted muted d-flex mb-1 flex-wrap">
+                        <span class="sr-only">
+                            {{#str}}aria:courseshortname, core_course{{/str}}
+                        </span>
+                        <div>
+                            {{{shortname}}}
+                        </div>
+                        {{$divider}}{{/divider}}
+                    </div>
+                    {{/showshortname}}
+                    <a href="{{viewurl}}" class="aalink coursename text-decoration-none ellipsis ellipsis-3 h-semibold-6" title="{{{fullname}}}">
+                        <span class="sr-only">
+                            {{#str}}aria:coursename, core_course{{/str}}
+                        </span>
+                        {{$coursename}}{{/coursename}}
+                    </a>
+                </div>
+            </div>
+            {{#instructor}}
+            <div class="d-flex flex-row flex-gap-0d5">
+                <div class="d-flex flex-row instructor-info-wrapper">
+                    <a href="{{ url }}" class="d-flex align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
+                        aria-label="Instructor for {{coursename}} is - {{name}}" title="{{{name}}}">
+                        <img src="{{ picture }}" class="rounded-circle" alt="{{ name }}" loading="lazy"/>
+                        <h6 class="h-regular-6 course-instructors m-0" title="{{{name}}}">{{{name}}}</h6>
+                    </a>
+                </div>
+                {{#instructorcount}}<span class="small-info-semibold instructorscount d-flex align-items-center justify-content-center">+{{instructorcount}}</span>{{/instructorcount}}
+            </div>
+            {{/instructor}}
+        </div>
+	    <div class="edw-card-design-ft d-flex flex-column align-self-strech flex-gap-5">
+            <div class="progress-data-wrapper">
+                {{$progress}}{{/progress}}
+            </div>
+            <a class="btn btn-secondary btn-sm view-course-btn ml-auto" href="{{viewurl}}" title="{{#str}}viewcoursetitle,theme_remui{{/str}}">{{#str}}viewcourse,theme_remui{{/str}}</a>
+        </div>
+    </div>
+</div>

--- a/theme/inteb/templates/core_courseformat/local/courseindex/cm.mustache
+++ b/theme/inteb/templates/core_courseformat/local/courseindex/cm.mustache
@@ -1,0 +1,89 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle. If not, see <http: //www.gnu.org/licenses />.
+
+    Edwiser RemUI
+    @package theme_remui
+    @copyright (c) 2023 WisdmLabs (https://wisdmlabs.com/)
+    @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+{{!
+    @template core_courseformat/local/courseindex/cm
+
+    Displays a course index course-module entry.
+
+    Example context (json):
+    {
+    "id": "12",
+    "name": "Announcements",
+    "url": "#",
+    "visible": 1,
+    "isactive": 1,
+    "uniqid": "0",
+    "accessvisible": 1,
+    "hascmrestrictions": 0
+    }
+}}
+<li class="courseindex-item
+        {{#isactive}}active{{/isactive}}
+        {{#hascmrestrictions}}restrictions{{/hascmrestrictions}}
+        {{^accessvisible}}dimmed{{/accessvisible}}
+        {{#indent}} indented {{/indent}}
+
+        {{#hasdelegatedsection}}py-0{{/hasdelegatedsection}}
+
+        {{#url}} d-flex {{/url}} {{^url}} d-flex-noedit {{/url}}"
+    id="{{uniqid}}-course-index-cm-{{id}}"
+    data-for="cm"
+    data-id="{{id}}"
+    role="treeitem"
+>
+    {{^hasdelegatedsection}}
+        <div class="edw-section-content-wrapper text-truncate align-items-center">
+        <span class="completioninfo" data-for="cm_completion" data-value="NaN"></span>
+        {{#uservisible}}
+        <a
+            class="courseindex-link text-truncate text-link-regular"
+            {{#url}} href="{{{url}}}" {{/url}}{{^url}} href="#{{{anchor}}}" data-anchor="true" {{/url}}
+            data-for="cm_name"
+            tabindex="-1"
+        >
+            {{{name}}}
+        </a>
+        {{/uservisible}}
+        {{^uservisible}}
+        <a class="courseindex-link text-truncate text-link-regular" href="#{{{anchor}}}" data-for="cm_name" tabindex="-1" data-anchor="true">
+            {{{name}}}
+        </a>
+        {{/uservisible}}
+        </div>
+        <div class="edw-section-content-icon-wrapper align-items-center">
+            <span class="courseindex-locked " data-for="cm_name">
+                {{#pix}} t/locked, core {{/pix}}
+            </span>
+            <span class="dragicon "><span class="edw-icon edw-edw-icon edw-icon-Move"></span></span>
+        </div>
+    {{/hasdelegatedsection}}
+    {{#hasdelegatedsection}}
+        {{#sectioninfo}}
+            {{> core_courseformat/local/courseindex/section}}
+        {{/sectioninfo}}
+    {{/hasdelegatedsection}}
+</li>
+{{#js}}
+require(['core_courseformat/local/courseindex/cm'], function(component) {
+component.init('{{uniqid}}-course-index-cm-{{id}}');
+});
+{{/js}}

--- a/theme/inteb/templates/core_courseformat/local/courseindex/section.mustache
+++ b/theme/inteb/templates/core_courseformat/local/courseindex/section.mustache
@@ -1,0 +1,132 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+    Edwiser RemUI
+    @package theme_remui
+    @copyright (c) 2023 WisdmLabs (https://wisdmlabs.com/)
+    @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+{{!
+    @template core_courseformat/local/courseindex/section
+
+    Displays a course index section entry.
+
+    Example context (json):
+    {
+        "title": "General",
+        "id": 23,
+        "uniqid": "0",
+        "number": 1,
+        "sectionurl": "#",
+        "indexcollapsed": 0,
+        "current": 1,
+        "visible": 1,
+        "hasrestrictions": 0,
+        "cms": [
+            {
+                "id": 10,
+                "name": "Glossary of characters",
+                "url": "#",
+                "visible": 1,
+                "isactive": 0
+            },
+            {
+                "id": 11,
+                "name": "World Cinema forum",
+                "url": "#",
+                "visible": 1,
+                "isactive": 0
+            },
+            {
+                "id": 12,
+                "name": "Announcements",
+                "url": "#",
+                "visible": 0,
+                "isactive": 1
+            }
+        ]
+    }
+}}
+<div
+    class="courseindex-section w-100 {{#current}}current{{/current}}  {{#component}}delegated-section{{/component}}"
+    id="{{uniqid}}-course-index-section-{{id}}"
+    data-for="section"
+    data-id="{{id}}"
+    data-number="{{number}}"
+    role="treeitem"
+    aria-owns="courseindexcollapse{{number}}"
+>
+    <div class="courseindex-item d-flex align-items-center
+            {{^visible}}dimmed{{/visible}}
+            {{#hasrestrictions}}restrictions{{/hasrestrictions}}
+            courseindex-section-title"
+        id="courseindexsection{{number}}"
+        data-for="section_item"
+    >
+        <a href="{{{sectionurl}}}"
+            class="courseindex-link text-truncate text-link-semibold"
+            data-action="togglecourseindexsection"
+            data-for="section_title"
+            tabindex="-1"
+            title=" {{{title}}}"
+        >
+            {{{title}}}
+        </a>
+  <div class="edw-title-icon-wrapper">
+    <span class="current-badge badge badge-primary  px-2 rounded-pill">
+        {{highlighted}}
+    </span>
+    <span class="courseindex-locked " data-for="cm_name">
+        {{#pix}} t/locked, core {{/pix}}
+    </span>
+    <span class="dragicon "><span class="edw-icon edw-edw-icon edw-icon-Move"></span></span>
+    <a data-toggle="collapse"
+    href="#courseindexcollapse{{number}}"
+    class="courseindex-chevron icons-collapse-expand collapsed p-0"
+    aria-expanded="false"
+    aria-controls="courseindexcollapse{{number}}"
+    tabindex="-1"
+>
+    <span class="collapsed-icon icon-no-margin"
+        title="{{#str}} expand, core {{/str}}">
+        <span class="dir-rtl-hide"><span class="edw-icon edw-icon-Down-Arrow"></span></span>
+        <span class="dir-ltr-hide"><span class="edw-icon edw-icon-Down-Arrow"></span></span>
+        <span class="sr-only">{{#str}} expand, core {{/str}}</span>
+    </span>
+    <span class="expanded-icon icon-no-margin "
+        title="{{#str}} collapse, core {{/str}}">
+        <span class="edw-icon edw-icon-UpArrow"></span>
+        <span class="sr-only">{{#str}} collapse, core {{/str}}</span>
+    </span>
+</a>
+  </div>
+    </div>
+    <div id="courseindexcollapse{{number}}"
+        class="courseindex-item-content collapse"
+        aria-labelledby="courseindexsection{{number}}" role="group"
+    >
+        <ul class="courseindex-sectioncontent unlist" data-for="cmlist" data-id="{{id}}" role="group">
+            {{#cms}}
+            {{> core_courseformat/local/courseindex/cm }}
+            {{/cms}}
+        </ul>
+    </div>
+</div>
+{{#js}}
+require(['core_courseformat/local/courseindex/section'], function(component) {
+    component.init('{{uniqid}}-course-index-section-{{id}}');
+});
+{{/js}}

--- a/theme/inteb/templates/enrolpage.mustache
+++ b/theme/inteb/templates/enrolpage.mustache
@@ -1,0 +1,318 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+    Edwiser RemUI
+    @package theme_remui
+    @copyright (c) 2023 WisdmLabs (https://wisdmlabs.com/)
+    @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+}}
+{{!
+    @template theme_remui/enrolpage
+
+    remui drawer template.
+
+    Context variables required for this template:
+    * sitename - The name of the site
+    * output - The core renderer for the page
+    * bodyattributes - attributes for the body tag as a string of html attributes
+    * sidepreblocks - HTML for the blocks
+    * hasblocks - true if there are blocks on this page
+    * courseindexopen - true if the nav drawer should be open on page load
+    * regionmainsettingsmenu - HTML for the region main settings menu
+    * hasregionmainsettingsmenu - There is a region main settings menu on this page.
+
+    Example context (json):
+    {
+        "sitename": "Moodle",
+        "output": {
+            "doctype": "<!DOCTYPE html>",
+            "page_title": "Test page",
+            "favicon": "favicon.ico",
+            "main_content": "<h1>Headings make html validators happier</h1>"
+         },
+        "bodyattributes":"",
+        "sidepreblocks": "<h2>Blocks html goes here</h2>",
+        "hasblocks":true,
+        "courseindexopen": true,
+        "navdraweropen": false,
+        "blockdraweropen": true,
+        "regionmainsettingsmenu": "",
+        "hasregionmainsettingsmenu": false,
+        "addblockbutton": ""
+    }
+}}
+{{> theme_remui/common_start}}
+<div id="page-content" class="pb-3 d-print-block">
+    <div id="region-main-box">
+        {{#hasregionmainsettingsmenu}}
+        <div id="region-main-settings-menu" class="d-print-none">
+            <div> {{{ regionmainsettingsmenu }}} </div>
+        </div>
+        {{/hasregionmainsettingsmenu}}
+        <section id="region-main" aria-label="{{#str}}content{{/str}}">
+            {{#hasregionmainsettingsmenu}}
+                <div class="region_main_settings_menu_proxy"></div>
+            {{/hasregionmainsettingsmenu}}
+            {{{ output.course_content_header }}}
+            {{#headercontent}}
+                {{> core/activity_header }}
+            {{/headercontent}}
+            {{#overflow}}
+                <div class="container-fluid tertiary-navigation">
+                    <div class="navitem">
+                        {{> core/url_select}}
+                    </div>
+                </div>
+            {{/overflow}}
+
+            {{#enrolment}}
+                {{#ismanager}}
+                <a href="{{{courseurl}}}" class="btn btn-secondary btn-sm btn-backtocourse d-flex align-items-center p-mb-5">
+                    <span class="edw-icon edw-icon-Left-Arrow"></span>
+                    {{#str}}backtothecourse, theme_remui{{/str}}
+                </a>
+                {{/ismanager}}
+            {{/enrolment}}
+            
+            {{#enrolment}}
+                <div class="enrollment-sections">
+                    {{#headersection}}
+                    {{> theme_remui/enrol_headersection}}
+                    {{/headersection}}
+
+                    {{#pricingsection}}
+                    {{> theme_remui/enrol_pricingsection}}
+                    {{/pricingsection}}
+
+                    {{#courseoverview}}
+                    {{> theme_remui/enrol_courseoverview}}
+                    {{/courseoverview}}
+
+                </div>
+            {{/enrolment}}
+            {{#enrolment}}
+                {{#editing}}
+                    <div class="ml-auto d-flex justify-content-end flex-gap-2">
+                        <a href="{{editenrolmethodspagelink}}" target="_blank" class="textlink-with-icon text-link-semibold d-flex flex-gap-0d5 align-items-center p-py-2 p-px-3">
+                            <span>{{#str}}updateenrollmentmethods, theme_remui, {{#str}}enrolment, enrol{{/str}}{{/str}}</span>
+                            <span class="edw-icon edw-icon-Shortcut"></span>
+                        </a>
+                        <a href="#" target="_blank" class="textlink-with-icon text-link-semibold  flex-gap-0d5 align-items-center p-py-2 p-px-3 hide-enrol-option-btn
+                            {{#enrolloptionshidden}}d-none{{/enrolloptionshidden}}
+                            {{^enrolloptionshidden}}d-flex{{/enrolloptionshidden}}
+                        ">
+                            <span class="edw-icon edw-icon-Hide"></span>
+                            <span>{{#str}}hideenrollmentoptions, theme_remui, {{#str}}enrolment, enrol{{/str}}{{/str}}</span>
+                        </a>
+                        <a href="#" target="_blank" class="textlink-with-icon  text-link-semibold  flex-gap-0d5 align-items-center p-py-2 p-px-3 show-enrol-option-btn
+                            {{#enrolloptionshidden}}d-flex{{/enrolloptionshidden}}
+                            {{^enrolloptionshidden}}d-none{{/enrolloptionshidden}}
+                        ">
+                            <span class="edw-icon edw-icon-Show"></span>
+                            <span>{{#str}}showenrollmentoptions, theme_remui,{{#str}}enrolment, enrol{{/str}}{{/str}}</span>
+                        </a>
+                    </div>
+                {{/editing}}
+            {{/enrolment}}
+
+            <div class="doted-border enrol-main-area-wrapper {{#enrolment}}{{#enrolloptionshidden}}d-none{{/enrolloptionshidden}}{{/enrolment}}">
+                {{{ output.main_content }}}
+                {{#enrolment}}{{{csstohidemainarearemuifields}}}{{/enrolment}}
+            </div>
+            {{#enrolment}}
+            {{#editing}}
+            <div id="maincontent2" class ="doted-border h-100 p-p-5 enrol-mainarea-hidden-contentainer {{#enrolment}}{{^enrolloptionshidden}}d-none{{/enrolloptionshidden}}{{/enrolment}}">
+                <div  class="empty-box p-p-6 d-flex justify-content-center align-items-center">
+                    <p class="m-0 para-semibold-2">
+                        {{#str}}sectionishiddenmessage, theme_remui{{/str}}
+                    </p>
+                </div>
+            </div>
+            {{/editing}}
+            {{/enrolment}}
+            {{{ output.activity_navigation }}}
+            
+            {{#enrolment}}
+            <div class="doted-border p-mt-11 {{#editing}}p-py-5 p-px-4{{/editing}}">
+                {{#editing}}
+                    <a href="{{editreletedlatestsettinglink}}" target="_blank" class="textlink-with-icon text-link-semibold d-flex flex-gap-0d5 align-items-center p-py-2 p-mx-3 ml-auto p-mb-8">
+                        <span>{{#str}}editcoursessectionsettings, theme_remui{{/str}}</span>
+                        <span class="edw-icon edw-icon-Shortcut"></span>
+                    </a>
+                {{/editing}}
+                {{#showrelatedcoursesblock}}
+                    {{#hasrelatedcourses}}
+                        <div class="enroll-page-relatedcourses d-flex flex-column flex-gap-8 ">
+                            <div class="d-flex  justify-content-between align-items-center">
+                                <h3 class="h-semibold-3 m-0">
+                                    {{#str}}enrol_relatedcourses,theme_remui{{/str}}
+                                </h3>
+                                <div class="header-content-wrapper ">
+                                    <a href='{{coursearcivecaturl}}' class="h-semibold-6 m-0 text-decoration-none ">{{#str}}enrol_viewall,theme_remui{{/str}}</a>
+                                </div>
+                            </div>
+                            <div class="relatedcourses-wrapper edw-course-card-grid p-px-3">
+                                {{#relatedcourses}}
+                                    {{{relatedcourses}}}
+                                {{/relatedcourses}}
+                            </div>
+                        </div>
+                    {{/hasrelatedcourses}}
+                    {{^hasrelatedcourses}}
+                        {{#editing}}
+                            <div class="doted-border bg-white p-p-5">
+                                <div  class="empty-box p-p-6 d-flex justify-content-center align-items-center">
+                                    <p class="m-0 para-semibold-2">
+                                        {{#str}}norelatedcoursemessage, theme_remui{{/str}}
+                                    </p>
+                                </div>
+                            </div>
+                        {{/editing}}
+                    {{/hasrelatedcourses}}
+                {{/showrelatedcoursesblock}}
+
+                {{#showlatestcoursesblock}}
+                    {{#haslatestcourses}}
+                        <div class="enroll-page-latestcourses p-mt-11 d-flex flex-column flex-gap-8">
+                            <div class="d-flex flex-column flex-gap-1">
+                                <h3 class="h-semibold-3 m-0">
+                                    {{#str}}enrol_latestcourses,theme_remui{{/str}}
+                                </h3>
+                            </div>
+                            <div class="latestcourses-wrapper latestcourses-slick-wrapper">
+                                {{#latestcourses}}
+                                    {{{latestcourses}}}
+                                {{/latestcourses}}
+                            </div>
+                            <div class='latest-available-courses button-container w-100 text-center '>
+                                <button type='button' class='btn btn-floating btn-primary btn-prev btn-sm'  title='Previous button'>
+                                    <span class='edw-icon edw-icon-Left-Arrow' aria-hidden='true'></span>
+                                </button>
+                                <button type='button' class='btn btn-floating btn-primary btn-next btn-sm '  title='Next button'>
+                                    <span class='edw-icon edw-icon-Right-Arrow' aria-hidden='true'></span>
+                                </button>
+                            </div>
+                        </div>
+                    {{/haslatestcourses}}
+                    {{^haslatestcourses}}
+                        {{#editing}}
+                            <div class="doted-border bg-white p-p-5 p-mt-6">
+                                <div  class="empty-box p-p-6 d-flex justify-content-center align-items-center">
+                                    <p class="m-0 para-semibold-2">
+                                        {{#str}}nolatestcoursemessage, theme_remui{{/str}}
+                                    </p>
+                                </div>
+                            </div>
+                        {{/editing}}
+                    {{/haslatestcourses}}
+                {{/showlatestcoursesblock}}
+            </div>
+            {{/enrolment}}
+            {{{ output.course_content_footer }}}
+
+        </section>
+    </div>
+</div>
+{{> theme_remui/common_end}}
+
+{{#focusdata.enabled}}
+{{#js}}
+require(['theme_remui/focusmode'], function(focusmode){
+ focusmode.init({{focusdata.on}});
+});
+{{/js}}
+{{/focusdata.enabled}}
+
+{{#js}}
+    require(['theme_remui/enrolpage'], function(Enrol){
+        Enrol.init();
+    });
+{{/js}}
+
+
+{{#js}}
+require(['jquery', 'theme_remui/slick'], function ($) {
+$(document).ready(function(){
+    $('.latestcourses-slick-wrapper').slick({
+        dots: false,
+        arrows: true,
+        infinite: false,
+        speed: 500,
+        prevArrow: $(".latest-available-courses.button-container .btn-prev"),
+        nextArrow: $(".latest-available-courses.button-container .btn-next"),
+        rtl: ($("html").attr("dir") == "rtl") ? true : false,
+        {{#enrolment}}
+            {{#hasnarrowidth}}
+                slidesToShow: 3,
+                slidesToScroll: 3,
+                responsive: [{
+                    breakpoint: 1200,
+                    settings: {
+                    slidesToShow: 3,
+                    slidesToScroll: 3
+                    }
+                }, {
+                    breakpoint: 1024,
+                    settings: {
+                    slidesToShow: 2,
+                    slidesToScroll: 2
+                    }
+                }, {
+                    breakpoint: 768,
+                    settings: {
+                    slidesToShow: 1,
+                    slidesToScroll: 1
+                    }
+                }
+                ]
+            {{/hasnarrowidth}}
+
+            {{^hasnarrowidth}}
+                slidesToShow: 4,
+                slidesToScroll: 4,
+                responsive: [{
+                    breakpoint: 1200,
+                    settings: {
+                    slidesToShow: 3,
+                    slidesToScroll: 3
+                    }
+                }, {
+                    breakpoint: 1024,
+                    settings: {
+                    slidesToShow: 2,
+                    slidesToScroll: 2
+                    }
+                }, {
+                    breakpoint: 768,
+                    settings: {
+                    slidesToShow: 1,
+                    slidesToScroll: 1
+                    }
+                }
+                ]
+            {{/hasnarrowidth}}
+
+        {{/enrolment}}
+
+      })
+      .on('setPosition', function (event, slick) {
+        slick.$slides.css('height', slick.$slideTrack.height() + 'px');
+        $('.slick-slide > div').css('height', '100%');
+      });
+      $('.slick-slide-container.slick-slider.d-none').removeClass('d-none');
+});
+});
+{{/js}}

--- a/theme/inteb/templates/mod_quiz/view_page.mustache
+++ b/theme/inteb/templates/mod_quiz/view_page.mustache
@@ -1,0 +1,18 @@
+{{!
+    Template to render the quiz view page with centred description and start button.
+    This overrides the default layout to ensure elements are centred.
+}}
+<div class="mod-quiz-view">
+    {{#intro}}
+    <div id="intro" class="generalbox quiz-intro text-center">
+        {{{intro}}}
+    </div>
+    {{/intro}}
+    {{#buttontext}}
+    <div class="quiz-start text-center">
+        <form action="{{startattempturl}}" method="get" class="quizstartbuttondiv">
+            <button type="submit" class="btn btn-primary">{{buttontext}}</button>
+        </form>
+    </div>
+    {{/buttontext}}
+</div>

--- a/theme/inteb/templates/theme_remui/course_card_grid.mustache
+++ b/theme/inteb/templates/theme_remui/course_card_grid.mustache
@@ -23,7 +23,7 @@
 
 <div class="course_card-0 card-wrapper card dashboard-card edwanimate-{{animation}}"  data-course-id="{{id}}">
     <div tabindex="-1">
-        <div class="card-img dashboard-card-img p-p-4 edw-course-img-wrapper" style='background-image: url("{{{courseimage}}}");'>
+        <div class="card-img dashboard-card-img p-p-4 edw-course-img-wrapper" style='background-image: url("{{#remuicourseimage}}{{remuicourseimage}}{{/remuicourseimage}}{{^remuicourseimage}}{{{courseimage}}}{{/remuicourseimage}}");'>
             <a href="{{ courseurl }} " class="view-course-url"></a>
             <div class="card-img-icons-wrapper d-flex align-items-center flex-gap-2 ml-auto">
                 {{^visible}}
@@ -50,7 +50,7 @@
                         </a>
                     </div>
                 </div>
-                {{#instructors}}
+                {{#instructor}}
                     <div class="d-flex flex-row flex-gap-0d5">
                         <div class="d-flex flex-row instructor-info-wrapper">
                             <a href="{{ url }}" class="d-flex  align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
@@ -66,7 +66,7 @@
                             </span>
                         {{/instructorcount}}
                     </div>
-                {{/instructors}}
+                {{/instructor}}
 
                 {{#coursesummary}}
                     <p class="coursesummary ellipsis ellipsis-2 para-regular-2 m-0">{{{coursesummary}}}</p>

--- a/theme/inteb/templates/theme_remui/course_card_list.mustache
+++ b/theme/inteb/templates/theme_remui/course_card_list.mustache
@@ -23,7 +23,7 @@
 
 <li class="list-group-item course-listitem  d-flex edw-course-list edwanimate-{{animation}}"  data-animate="{{animation}}" data-course-id="{{id}}" >
     <div class="edw-course-img-wrapper">
-        <div class="card-img dashboard-list-img  p-p-4" style='background-image: url("{{{courseimage}}}");'>
+        <div class="card-img dashboard-list-img  p-p-4" style='background-image: url("{{#remuicourseimage}}{{remuicourseimage}}{{/remuicourseimage}}{{^remuicourseimage}}{{{courseimage}}}{{/remuicourseimage}}");'>
             <a href="{{ courseurl }} " class="view-course-url"></a>
             <div class="card-img-icons-wrapper d-flex align-items-center flex-gap-2 ml-auto">
                 {{^visible}}
@@ -50,7 +50,7 @@
                     </div>
                 </div>
             </div>
-            {{#instructors}}
+            {{#instructor}}
             <div class="d-flex flex-row flex-gap-0d5">
                 <div class="d-flex flex-row instructor-info-wrapper">
                     <a href="{{ url }}" class="d-flex align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
@@ -62,7 +62,7 @@
                 {{#instructorcount}}<span
                     class="small-info-semibold instructorscount d-flex align-items-center justify-content-center" title="{{#str}}instructorcounttitle,theme_remui{{/str}}">+{{instructorcount}}</span>{{/instructorcount}}
             </div>
-            {{/instructors}}
+            {{/instructor}}
 
             {{#coursesummary}}
             <p class="coursesummary ellipsis ellipsis-2 para-regular-3 m-0">{{{coursesummary}}}</p>

--- a/theme/inteb/templates/theme_remui/course_card_summary.mustache
+++ b/theme/inteb/templates/theme_remui/course_card_summary.mustache
@@ -23,7 +23,7 @@
 
 <li class="list-group-item course-listitem  d-flex edw-course-list edwanimate-{{animation}}"  data-animate="{{animation}}" data-course-id="{{id}}">
     <div class="edw-course-img-wrapper">
-        <div class="summaryimage card-img dashboard-list-img  p-p-4" style='background-image: url("{{{courseimage}}}");'>
+        <div class="summaryimage card-img dashboard-list-img  p-p-4" style='background-image: url("{{#remuicourseimage}}{{remuicourseimage}}{{/remuicourseimage}}{{^remuicourseimage}}{{{courseimage}}}{{/remuicourseimage}}");'>
             <a href="{{ courseurl }} " class="view-course-url"></a>
             <div class="card-img-icons-wrapper d-flex align-items-center flex-gap-2 ml-auto">
                 {{^visible}}
@@ -51,22 +51,22 @@
                     </div>
                 </div>
             </div>
-            {{#instructors}}
-            <div class="d-flex flex-row flex-gap-0d5">
-                <div class="d-flex flex-row instructor-info-wrapper">
-                    <a href="{{ url }}" class="d-flex align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
-                        aria-label="Instructor for {{coursename}} is - {{name}}" title="{{{name}}}">
-                        <img src="{{ picture }}" class="rounded-circle" alt="{{ name }}" loading="lazy"/>
-                        <h6 class="h-regular-6 course-instructors m-0 break-word ellipsis ellipsis-2" title="{{{name}}}">{{{name}}}</h6>
-                    </a>
+            {{#instructor}}
+                <div class="d-flex flex-row flex-gap-0d5">
+                    <div class="d-flex flex-row instructor-info-wrapper">
+                        <a href="{{ url }}" class="d-flex align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
+                            aria-label="Instructor for {{coursename}} is - {{name}}" title="{{{name}}}">
+                            <img src="{{ picture }}" class="rounded-circle" alt="{{ name }}" loading="lazy"/>
+                            <h6 class="h-regular-6 course-instructors m-0 break-word ellipsis ellipsis-2" title="{{{name}}}">{{{name}}}</h6>
+                        </a>
+                    </div>
+                    {{#instructorcount}}
+                        <span class="small-info-semibold instructorscount d-flex align-items-center justify-content-center" title="{{#str}}instructorcounttitle,theme_remui{{/str}}">
+                        +{{instructorcount}}
+                        </span>
+                    {{/instructorcount}}
                 </div>
-                {{#instructorcount}}
-                    <span class="small-info-semibold instructorscount d-flex align-items-center justify-content-center" title="{{#str}}instructorcounttitle,theme_remui{{/str}}">
-                    +{{instructorcount}}
-                    </span>
-                {{/instructorcount}}
-            </div>
-            {{/instructors}}
+            {{/instructor}}
         </div>
         <div class="edw-card-design-ft d-flex flex-gap-3">
             <div class="d-flex text-nowrap ernr-lesson-wrapper flex-wrap">

--- a/theme/inteb/templates/theme_remui/enrol_page_coursecards.mustache
+++ b/theme/inteb/templates/theme_remui/enrol_page_coursecards.mustache
@@ -29,7 +29,7 @@
 <div class="course_card-0 card-wrapper card dashboard-card edwanimate-{{animation}} h-100 d-flex flex-column"  data-course-id="{{id}}">
     <div tabindex="-1">
         <div class="card-img dashboard-card-img p-p-4 edw-course-img-wrapper"
-            style='background-image: url("{{{courseimage}}}");'>
+            style='background-image: url("{{#remuicourseimage}}{{remuicourseimage}}{{/remuicourseimage}}{{^remuicourseimage}}{{{courseimage}}}{{/remuicourseimage}}");'>
             <a href="{{ courseurl }} " class="view-course-url"></a>
         </div>
     </div>
@@ -46,7 +46,7 @@
                         </a>
                     </div>
                 </div>
-                {{#instructors}}
+                {{#instructor}}
                     <div class="d-flex flex-row flex-gap-0d5">
                         <div class="d-flex flex-row instructor-info-wrapper">
                             <a href="{{ url }}" class="d-flex align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
@@ -63,7 +63,7 @@
                             </span>
                         {{/instructorcount}}
                     </div>
-                {{/instructors}}
+                {{/instructor}}
 
                 {{#coursesummary}}
                     <p class="coursesummary ellipsis ellipsis-2 para-regular-3 m-0">{{{coursesummary}}}</p>

--- a/theme/inteb/templates/theme_remui/frontpage_available_course.mustache
+++ b/theme/inteb/templates/theme_remui/frontpage_available_course.mustache
@@ -20,7 +20,7 @@
 
 <div class="course_card-0 card-wrapper card dashboard-card edwanimate-{{animation}} h-100 d-inline-flex" data-course-id="{{id}}">
     <div tabindex="-1">
-        <div class="card-img dashboard-card-img p-p-4 edw-course-img-wrapper" style='background-image: url("{{{courseimage}}}");'>
+        <div class="card-img dashboard-card-img p-p-4 edw-course-img-wrapper" style='background-image: url("{{#remuicourseimage}}{{remuicourseimage}}{{/remuicourseimage}}{{^remuicourseimage}}{{{courseimage}}}{{/remuicourseimage}}");'>
             <a href="{{ courseurl }} " class="view-course-url"></a>
         </div>
     </div>
@@ -37,7 +37,7 @@
                             href="{{courseurl}}"  title="{{{ coursename }}}">{{{coursename}}}</a>
                     </div>
                 </div>
-                {{#instructors}}
+                {{#instructor}}
                     <div class="d-flex flex-row flex-gap-d5">
                         <div class="d-flex flex-row instructor-info-wrapper">
                             <a href="{{ url }}" class="d-flex align-items-center flex-gap-d5 instructor-img {{ imgStyle }}"
@@ -46,14 +46,14 @@
                                 <h6 class="h-regular-6 course-instructors m-0 break-word ellipsis ellipsis-2" title="{{{name}}}">{{{name}}}</h6>
                             </a>
                         </div>
-                                
+
                         {{#instructorcount}}
                             <span class="small-info-semibold instructorscount d-flex align-items-center justify-content-center" title="{{#str}}instructorcounttitle,theme_remui{{/str}}">
                                 +{{instructorcount}}
                             </span>
                         {{/instructorcount}}
                     </div>
-                {{/instructors}}
+                {{/instructor}}
 
                 {{#coursesummary}}
                     <p class="coursesummary ellipsis ellipsis-2 para-regular-2 m-0">{{{coursesummary}}}</p>

--- a/theme/inteb/version.php
+++ b/theme/inteb/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_inteb';
-$plugin->version = 2025012206; // Fecha de la versión: Año, mes, día, incremento.
+$plugin->version = 2025012207; // Fecha de la versión: Año, mes, día, incremento.
 $plugin->requires = 2022041200; // Versión mínima de Moodle requerida.
 $plugin->release   = '4.5.0';
 $plugin->dependencies = [


### PR DESCRIPTION
## Summary
- collapse course index sections by default with white text and icons
- center quiz intro and start button in custom template
- highlight selected course categories using primary color
- style root-level course index items for consistent hover contrast

## Testing
- `n exec 22.11.0 npx stylelint theme/inteb/scss/inteb.scss` *(76 problems: 25 errors, 51 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bae42fc1a0832a888bbdca0cf050d0