### PR TITLE
Filter assignment grading table by role

### DIFF
--- a/local/assign_no_submission_filter/classes/hook_callbacks.php
+++ b/local/assign_no_submission_filter/classes/hook_callbacks.php
@@ -26,6 +26,8 @@ namespace local_assign_no_submission_filter;
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__ . '/../lib.php');
+
 /**
  * Hook callbacks class
  */
@@ -44,6 +46,10 @@ class hook_callbacks {
             return;
         }
         
+        if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
+            return;
+        }
+
         // Apply filtering preference
         if (get_config('local_assign_no_submission_filter', 'autoapply')) {
             set_user_preference('assign_filter', 'submitted', $USER);
@@ -63,6 +69,10 @@ class hook_callbacks {
             return;
         }
         
+        if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
+            return;
+        }
+
         // Apply our grading table override
         self::override_grading_table_class();
         
@@ -100,7 +110,11 @@ class hook_callbacks {
         if (!get_config('local_assign_no_submission_filter', 'enabled')) {
             return;
         }
-        
+
+        if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
+            return;
+        }
+
         // Add filter control UI
         $html = self::get_filter_controls_html();
         $hook->add_html($html);

--- a/local/assign_no_submission_filter/classes/observer.php
+++ b/local/assign_no_submission_filter/classes/observer.php
@@ -26,6 +26,8 @@ namespace local_assign_no_submission_filter;
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__ . '/../lib.php');
+
 /**
  * Event observer class
  */
@@ -44,12 +46,13 @@ class observer {
         $SESSION->assign_grading_assignid = $event->objectid;
         
         // Log filter usage
-        if (get_config('local_assign_no_submission_filter', 'enabled')) {
+        if (get_config('local_assign_no_submission_filter', 'enabled') &&
+            local_assign_no_submission_filter_user_has_role(\context::instance_by_id($event->contextid))) {
             self::log_filter_usage($event);
         }
-        
+
         // Apply filter preference
-        self::apply_filter_preference();
+        self::apply_filter_preference($event->contextid);
     }
     
     /**
@@ -75,14 +78,20 @@ class observer {
     /**
      * Apply filter preference for current user
      */
-    protected static function apply_filter_preference() {
+    protected static function apply_filter_preference(int $contextid) {
         global $USER, $SESSION;
-        
-        // Check if we should auto-apply filter
-        if (get_config('local_assign_no_submission_filter', 'autoapply')) {
-            set_user_preference('assign_filter', 'submitted', $USER);
-            $SESSION->assign_filter_applied = true;
+
+        if (!get_config('local_assign_no_submission_filter', 'autoapply')) {
+            return;
         }
+
+        $context = \context::instance_by_id($contextid);
+        if (!local_assign_no_submission_filter_user_has_role($context)) {
+            return;
+        }
+
+        set_user_preference('assign_filter', 'submitted', $USER);
+        $SESSION->assign_filter_applied = true;
     }
     
     /**

--- a/local/assign_no_submission_filter/lib.php
+++ b/local/assign_no_submission_filter/lib.php
@@ -44,13 +44,41 @@ function local_assign_no_submission_filter_get_submitted_users($assignid) {
 }
 
 /**
+ * Check if current user has one of the configured roles in a context.
+ *
+ * @param \context $context Context to check roles in.
+ * @return bool
+ */
+function local_assign_no_submission_filter_user_has_role(\context $context): bool {
+    global $USER;
+
+    $rolesconfig = get_config('local_assign_no_submission_filter', 'roles');
+    if (empty($rolesconfig)) {
+        return false;
+    }
+
+    $roleids = array_map('intval', explode(',', $rolesconfig));
+    foreach ($roleids as $roleid) {
+        if (user_has_role_assignment($USER->id, $roleid, $context->id)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Override the grading table class
  */
 function local_assign_no_submission_filter_override_grading_table() {
-    global $CFG;
+    global $CFG, $PAGE;
     
     // Check if we should override
     if (!get_config('local_assign_no_submission_filter', 'enabled')) {
+        return;
+    }
+
+    if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
         return;
     }
     


### PR DESCRIPTION
## Summary
- Ensure grading table override only applies to configured roles
- Verify filter hooks and event observers respect role configuration

## Testing
- `php -l local/assign_no_submission_filter/lib.php`
- `php -l local/assign_no_submission_filter/classes/hook_callbacks.php`
- `php -l local/assign_no_submission_filter/classes/observer.php`
- `phpunit local/assign_no_submission_filter` *(fails: Failed opening required '/workspace/Moodle_Dev/lib/phpunit/../../config.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bb371c8344832aa01f0464f28e0c0f