### PR TITLE
Hide non-submitted participants on grading page

### DIFF
--- a/local/assign_no_submission_filter/classes/custom_grading_table.php
+++ b/local/assign_no_submission_filter/classes/custom_grading_table.php
@@ -38,11 +38,11 @@ if (class_exists('\assign_grading_table')) {
          * Constructor - applies filtering
          */
         public function __construct($assignment, $perpage, $filter, $rowoffset, $quickgrading, $downloadfilename = null) {
-            // Force filter to 'submitted' if auto-apply is enabled
+            // Reset to default filter so drafts remain visible when auto-apply is enabled.
             if (get_config('local_assign_no_submission_filter', 'autoapply')) {
-                $filter = ASSIGN_FILTER_SUBMITTED;
+                $filter = ASSIGN_FILTER_NONE;
             }
-            
+
             parent::__construct($assignment, $perpage, $filter, $rowoffset, $quickgrading, $downloadfilename);
         }
         
@@ -71,12 +71,12 @@ if (class_exists('\assign_grading_table')) {
             
             // Add condition to only show users with submissions
             $submissionexists = "EXISTS (
-                SELECT 1 
-                FROM {assign_submission} s 
-                WHERE s.userid = u.id 
-                AND s.assignment = :assignid_filter_nsf 
-                AND s.latest = 1 
-                AND s.status = 'submitted'
+                SELECT 1
+                FROM {assign_submission} s
+                WHERE s.userid = u.id
+                AND s.assignment = :assignid_filter_nsf
+                AND s.latest = 1
+                AND s.status <> :status_new
             )";
             
             // Add to existing WHERE clause
@@ -91,6 +91,7 @@ if (class_exists('\assign_grading_table')) {
                 $this->sql->params = [];
             }
             $this->sql->params['assignid_filter_nsf'] = $assignid;
+            $this->sql->params['status_new'] = ASSIGN_SUBMISSION_STATUS_NEW;
         }
     }
     

--- a/local/assign_no_submission_filter/classes/filter_service.php
+++ b/local/assign_no_submission_filter/classes/filter_service.php
@@ -51,14 +51,18 @@ class filter_service {
      */
     public function user_has_submission($userid, $assignmentid) {
         return $this->db->record_exists_sql(
-            "SELECT 1 
-             FROM {assign_submission} 
-             WHERE userid = :userid 
-             AND assignment = :assignmentid 
-             AND latest = 1 
-             AND status = 'submitted'
+            "SELECT 1
+             FROM {assign_submission}
+             WHERE userid = :userid
+             AND assignment = :assignmentid
+             AND latest = 1
+             AND status <> :status_new
              AND timemodified IS NOT NULL",
-            ['userid' => $userid, 'assignmentid' => $assignmentid]
+            [
+                'userid' => $userid,
+                'assignmentid' => $assignmentid,
+                'status_new' => ASSIGN_SUBMISSION_STATUS_NEW,
+            ]
         );
     }
     
@@ -69,14 +73,17 @@ class filter_service {
      * @return array
      */
     public function get_users_with_submissions($assignmentid) {
-        $sql = "SELECT DISTINCT userid 
-                FROM {assign_submission} 
-                WHERE assignment = :assignmentid 
-                AND latest = 1 
-                AND status = 'submitted'
+        $sql = "SELECT DISTINCT userid
+                FROM {assign_submission}
+                WHERE assignment = :assignmentid
+                AND latest = 1
+                AND status <> :status_new
                 AND timemodified IS NOT NULL";
-        
-        return $this->db->get_fieldset_sql($sql, ['assignmentid' => $assignmentid]);
+
+        return $this->db->get_fieldset_sql($sql, [
+            'assignmentid' => $assignmentid,
+            'status_new' => ASSIGN_SUBMISSION_STATUS_NEW,
+        ]);
     }
     
     /**

--- a/local/assign_no_submission_filter/classes/hook_callbacks.php
+++ b/local/assign_no_submission_filter/classes/hook_callbacks.php
@@ -26,6 +26,8 @@ namespace local_assign_no_submission_filter;
 
 defined('MOODLE_INTERNAL') || die();
 
+require_once(__DIR__ . '/../lib.php');
+
 /**
  * Hook callbacks class
  */
@@ -44,9 +46,13 @@ class hook_callbacks {
             return;
         }
         
-        // Apply filtering preference
+        if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
+            return;
+        }
+
+        // Ensure default filter is used so only "no submission" rows are removed.
         if (get_config('local_assign_no_submission_filter', 'autoapply')) {
-            set_user_preference('assign_filter', 'submitted', $USER);
+            set_user_preference('assign_filter', ASSIGN_FILTER_NONE, $USER);
         }
     }
     
@@ -63,6 +69,10 @@ class hook_callbacks {
             return;
         }
         
+        if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
+            return;
+        }
+
         // Apply our grading table override
         self::override_grading_table_class();
         
@@ -100,7 +110,11 @@ class hook_callbacks {
         if (!get_config('local_assign_no_submission_filter', 'enabled')) {
             return;
         }
-        
+
+        if (!local_assign_no_submission_filter_user_has_role($PAGE->context)) {
+            return;
+        }
+
         // Add filter control UI
         $html = self::get_filter_controls_html();
         $hook->add_html($html);


### PR DESCRIPTION
## Summary
- Reset grading table filter to default and skip users whose latest submission is marked "new"
- Default hook and observer preferences to no filter so drafts remain visible
- Update helper queries to treat any non-"new" submission as valid

## Testing
- `php -l local/assign_no_submission_filter/lib.php`
- `php -l local/assign_no_submission_filter/classes/hook_callbacks.php`
- `php -l local/assign_no_submission_filter/classes/observer.php`
- `php -l local/assign_no_submission_filter/classes/custom_grading_table.php`
- `php -l local/assign_no_submission_filter/classes/filter_service.php`
- `phpunit local/assign_no_submission_filter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb371c8344832aa01f0464f28e0c0f