### PR TITLE
Implement hierarchical admin download selections

### DIFF
--- a/local/downloadcenter/classes/factory.php
+++ b/local/downloadcenter/classes/factory.php
@@ -295,7 +295,7 @@ class factory {
             raise_memory_limit($memorylimit);
         }
         if ($timelimit) {
-            core_php_time_limit::raise($timelimit);
+            \core_php_time_limit::raise($timelimit);
         }
         
         // Close session for performance.

--- a/local/downloadcenter/lang/en/local_downloadcenter.php
+++ b/local/downloadcenter/lang/en/local_downloadcenter.php
@@ -39,6 +39,7 @@ $string['download'] = 'Download';
 $string['downloadoptions'] = 'Download options';
 $string['selectcategory'] = 'Select category';
 $string['selectcourses'] = 'Select courses';
+$string['adminmultiselectinstructions'] = 'Select one or more categories to reveal their courses, then pick the courses and resources you wish to include in the administrator download.';
 $string['loadcourses'] = 'Load courses';
 $string['saveandcontinue'] = 'Save and continue';
 $string['clearselection'] = 'Clear selection';

--- a/local/downloadcenter/lang/es/local_downloadcenter.php
+++ b/local/downloadcenter/lang/es/local_downloadcenter.php
@@ -39,6 +39,7 @@ $string['download'] = 'Descargar';
 $string['downloadoptions'] = 'Opciones de descarga';
 $string['selectcategory'] = 'Seleccionar categoría';
 $string['selectcourses'] = 'Seleccionar cursos';
+$string['adminmultiselectinstructions'] = 'Seleccione una o varias categorías para ver sus cursos y elija los cursos y recursos que desea incluir en la descarga administrativa.';
 $string['loadcourses'] = 'Cargar cursos';
 $string['saveandcontinue'] = 'Guardar y continuar';
 $string['clearselection'] = 'Limpiar selección';

--- a/local/downloadcenter/styles.css
+++ b/local/downloadcenter/styles.css
@@ -105,52 +105,61 @@
 }
 
 /* Admin panel */
-.path-local-downloadcenter-admin .category-node {
-    margin-bottom: 10px;
-    border-left: 2px solid #dee2e6;
-    padding-left: 15px;
+.path-local-downloadcenter-admin .downloadcenter-tree-column {
+    max-height: 70vh;
+    overflow-y: auto;
+    padding-right: 1.5rem;
 }
 
-.path-local-downloadcenter-admin .category-header {
-    cursor: pointer;
-    padding: 8px;
-    background-color: #f8f9fa;
+.path-local-downloadcenter-admin .downloadcenter-options-column {
+    position: sticky;
+    top: 1.5rem;
+    align-self: flex-start;
+}
+
+.path-local-downloadcenter-admin .downloadcenter-category-tree details {
     border: 1px solid #dee2e6;
     border-radius: 4px;
-    margin-bottom: 5px;
-    transition: background-color 0.2s;
+    background-color: #fff;
+    margin-bottom: 0.75rem;
+    padding: 0.75rem 1rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
-.path-local-downloadcenter-admin .category-header:hover {
-    background-color: #e9ecef;
+.path-local-downloadcenter-admin .downloadcenter-category-tree summary {
+    cursor: pointer;
+    list-style: none;
 }
 
-.path-local-downloadcenter-admin .category-courses {
+.path-local-downloadcenter-admin .downloadcenter-category-tree summary::-webkit-details-marker {
     display: none;
-    padding-left: 20px;
 }
 
-.path-local-downloadcenter-admin .course-selector {
-    padding: 5px 0;
+.path-local-downloadcenter-admin .downloadcenter-category-tree .category-children {
+    margin-top: 0.75rem;
 }
 
-.path-local-downloadcenter-admin .course-selector.selected label {
-    background-color: #d4edda;
-    border-left: 3px solid #28a745;
-    padding-left: 5px;
+.path-local-downloadcenter-admin .downloadcenter-category-tree .downloadcenter-course {
+    border-left: 2px solid #e9ecef;
+    padding-left: 1rem;
+    margin-bottom: 0.5rem;
 }
 
-.path-local-downloadcenter-admin .downloadcenter-admin-panel {
-    position: sticky;
-    top: 20px;
+.path-local-downloadcenter-admin .downloadcenter-category-tree .downloadcenter-course summary {
+    font-weight: 600;
 }
 
-.path-local-downloadcenter-admin .selected-course {
-    transition: background-color 0.2s;
+.path-local-downloadcenter-admin .downloadcenter-category-tree .course-resources {
+    margin-top: 0.5rem;
 }
 
-.path-local-downloadcenter-admin .selected-course:hover {
-    background-color: #f8f9fa;
+.path-local-downloadcenter-admin .downloadcenter-category-tree .resource-item {
+    margin-bottom: 0.25rem;
+}
+
+.path-local-downloadcenter-admin .downloadcenter-category-tree .downloadcenter-section-title {
+    font-size: 0.95rem;
+    color: #495057;
 }
 
 /* Download options */


### PR DESCRIPTION
## Summary
- rework the multi-course admin manager to accept per-course resource selections while preserving download options
- replace the admin download page with a hierarchical category/course/resource selector and supporting helpers
- refresh styles and translations to guide administrators through the new selection workflow

## Testing
- php -l local/downloadcenter/classes/admin_manager.php
- php -l local/downloadcenter/index.php
- php -l local/downloadcenter/lang/en/local_downloadcenter.php
- php -l local/downloadcenter/lang/es/local_downloadcenter.php

------
https://chatgpt.com/codex/tasks/task_e_68cc0ec33a94832a8e0372f84934e9c5