### PR TITLE
Handle nested coursedata arrays for admin download center

### DIFF
--- a/local/downloadcenter/index.php
+++ b/local/downloadcenter/index.php
@@ -165,7 +165,8 @@ if ($mode === 'admin' && $isadmin) {
     try {
         $rawcoursedata = optional_param_array('coursedata', null, PARAM_RAW);
     } catch (\coding_exception $exception) {
-        if (strpos($exception->getMessage(), 'clean() can not process arrays') === false) {
+        $message = $exception->getMessage();
+        if (stripos($message, 'can not process arrays') === false) {
             throw $exception;
         }
         $rawcoursedata = null;


### PR DESCRIPTION
## Summary
- handle coding exceptions from optional_param_array when coursedata submissions include nested arrays by matching array-processing error messages case-insensitively

## Testing
- php -l local/downloadcenter/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d40a2ea580832a8b14a6c8aedc3e69