### PR TITLE
Fix chatbot hook registration return

### DIFF
--- a/local/chatbot/CHANGELOG.md
+++ b/local/chatbot/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## 1.0.0 - 2024-05-24
+## 1.0.1 - 2025-02-15
+- Convert the widget injector to the Moodle `before_footer_html_generation` hook API and stop echoing output directly (`lib.php`, `db/hooks.php`).
+- Return the hook definition array so Moodle registers the widget callback reliably (`db/hooks.php`).
+- Default the plugin to enabled on fresh installs/upgrades and persist the setting through an upgrade step (`lib.php`, `db/upgrade.php`).
+- Propagate message timestamps to web service consumers and surface them in the UI/history replay (`lib.php`, `externallib.php`, `amd/src/chatbot.js`).
+- Add launcher badge handling, local/session storage fallbacks and hardened UI interactions (`amd/src/chatbot.js`).
+- Guard against missing users in exports and refresh documentation to include installation, upgrade and validation guidance (`lib.php`, `README.md`).
 
+## 1.0.0 - 2024-05-24
 - Rebuilt the chatbot widget to match the `local_geniai` floating UI using a new Mustache template and AMD module.
 - Added a real conversation log table (`local_chatbot_logs`) with export and feedback capabilities.
 - Simplified configuration options with clear Moodle language strings and capability checks.

--- a/local/chatbot/README.md
+++ b/local/chatbot/README.md
@@ -1,70 +1,109 @@
-# Moodle local\_chatbot
+# Moodle local_chatbot
 
-A lightweight Moodle plugin that adds a floating, Moodle-native chatbot widget to every page for authenticated users. The widget mimics the position and behaviour of the `local_geniai` assistant while answering questions using simple keyword matching and quick action shortcuts to relevant Moodle pages.
+`local_chatbot` adds a floating assistant to Moodle pages that mirrors the positioning and look & feel of the `local_geniai` widget while providing a lightweight, keyword-based responder. The widget is injected through Moodle's `before_footer_html_generation` hook, uses a Mustache template for markup, an AMD module for interactivity and logs every dialogue in a dedicated database table.
 
-## Features
+## Feature highlights
 
-- Floating launcher with modern UI inspired by `local_geniai`.
-- Server-side keyword matcher with configurable fallback and welcome messages.
-- Quick actions that link to common areas such as the user profile and calendar.
-- Optional conversation export (HTML/CSV/JSON) when the user has the export capability.
-- Conversation history persisted in the `local_chatbot_logs` table.
-- Accessible Mustache template and AMD module written against Moodle 4.3 APIs.
+- Floating launcher with badge counter and animated popup styled after `local_geniai` (`templates/widget.mustache`, `styles.css`).
+- Accessible chat surface with welcome prompt, quick actions, suggestions and typing indicator (Mustache + AMD module).
+- Keyword-driven responder with configurable welcome/fallback messaging and intent tagging (`lib.php`).
+- AJAX web services for messaging, history replay, quick actions, exports and feedback (`db/services.php`, `externallib.php`).
+- Conversation log table with HTML, CSV or JSON export (`install.xml`, `lib.php`, `export.php`).
+- Granular capabilities for usage, management and exporting plus Site administration pages for future expansion (`db/access.php`, `settings.php`, `admin/*`).
 
-## Requirements
+## Requirements and compatibility
 
-- Moodle 4.3 (build 2023100900) or higher.
-- PHP 8.0 or later.
+| Requirement | Minimum |
+|-------------|---------|
+| Moodle core | 4.3 (build 2023100900) |
+| PHP         | 8.0 |
+| Database    | Any Moodle supported DB (table defined in `db/install.xml`) |
+
+The widget is injected only for authenticated, non-guest users on layouts that allow popup notifications.
 
 ## Installation
 
-1. Copy this directory to `moodle/local/chatbot` or clone the repository inside the `local` folder.
-2. Log in as an administrator and follow the upgrade notifications to install the plugin.
-3. Run Moodle cron so the caches are rebuilt: `php admin/cli/cron.php`.
+1. Copy this directory to `<moodle_root>/local/chatbot` or clone the repository inside `local/`.
+2. From the Moodle web UI or CLI run the upgrade step (`php admin/cli/upgrade.php`).
+3. (Optional) Purge caches after installation (`php admin/cli/purge_caches.php`).
+4. Run Moodle cron so caches are rebuilt (`php admin/cli/cron.php`).
 
-The plugin loads the AMD source module directly so the repository does not ship minified assets. When deploying to production you may optionally generate minified builds with Moodle's AMD tooling:
+The AMD controller is loaded directly from `amd/src/chatbot.js`; no additional build step is required for production. If you prefer minified assets, run `npx grunt amd`.
 
-```bash
-npx grunt amd
-```
+## Upgrading
+
+- Version 1.0.1 introduces the badge counter, timestamp propagation, stronger hook integration and ensures the widget defaults to enabled. During upgrade a default `enabled` config value is created when missing (`db/upgrade.php`).
+- After replacing the plugin directory, repeat the installation steps above. Moodle will apply outstanding database or configuration upgrades automatically.
 
 ## Configuration
 
-Navigate to **Site administration → Plugins → Local plugins → Chatbot assistant** to configure:
+Navigate to **Site administration → Plugins → Local plugins → Chatbot assistant** (`settings.php`) to manage:
 
-- **Enable chatbot:** Toggle the floating widget on/off.
-- **Assistant name:** Header text and aria labels used by the widget.
-- **Widget position:** Bottom-right (default) or bottom-left.
-- **Theme:** Choose between modern, minimal or dark styles.
-- **Welcome message:** Shown the first time a user opens the chatbot.
-- **Fallback response:** Message returned when no keyword matches.
-- **Maximum message length:** Client-side limit for user messages.
-- **Allow conversation export:** Show the export button for users with `local/chatbot:export`.
+- Enable chatbot (defaults to on).
+- Assistant name shown in the header and aria labels.
+- Launcher position (bottom-right or bottom-left).
+- Theme palette (modern, minimal, dark).
+- Welcome message template supporting `{name}` token replacement.
+- Fallback response when no keyword is matched.
+- Maximum message length enforced in the UI.
+- Toggle for exposing the export button (requires `local/chatbot:export`).
 
 ## Capabilities
 
-| Capability | Description | Default roles |
-|------------|-------------|----------------|
-| `local/chatbot:use` | Use the widget and send messages | All authenticated users |
-| `local/chatbot:manage` | Access configuration pages | Manager |
-| `local/chatbot:export` | Export conversation history | All authenticated users |
+| Capability | Purpose | Default roles |
+|------------|---------|----------------|
+| `local/chatbot:use` | Launch the widget and call web services | Authenticated users |
+| `local/chatbot:manage` | Access placeholder admin consoles | Manager |
+| `local/chatbot:export` | Export chat history | Authenticated users |
 
-## Usage
+## Widget behaviour and assets
 
-After installation the widget automatically appears for authenticated users on pages where popup notifications are allowed. Open the launcher, type a message and the assistant will respond. Quick action buttons and suggested prompts offer shortcuts to frequently visited areas in Moodle.
+- HTML is rendered from `templates/widget.mustache`, replicating `local_geniai` launcher/header layout and ARIA labelling.
+- Styling lives in `styles.css` with responsive rules that mirror the reference plugin.
+- `amd/src/chatbot.js` boots the widget, talks to web services, shows history, updates the launcher badge when new bot replies arrive and honours local/session storage for persistence.
+- Server bootstrap (`lib.php`) injects CSS/JS, builds the template context, enforces capabilities and passes localisation strings plus runtime config to the AMD module.
+
+## Web services
+
+All services are defined in `db/services.php` and implemented in `externallib.php`:
+
+- `local_chatbot_process_message`: keyword response, intent tagging, quick actions & suggestions.
+- `local_chatbot_get_history`: returns the latest messages with timestamps for replay.
+- `local_chatbot_get_suggestions`: contextual prompt suggestions.
+- `local_chatbot_get_quick_actions`: shortcut buttons (profile, calendar, etc.).
+- `local_chatbot_export_conversation`: server-side HTML/CSV/JSON export used by the widget and standalone export page.
+- `local_chatbot_feedback`: stores thumbs-up/down feedback on each log entry.
+- `local_chatbot_execute_action`: executes quick action shortcuts (placeholder).
+
+## Data storage
+
+The plugin creates `local_chatbot_logs` (`db/install.xml`) capturing:
+
+- `userid`, `sessionid`, original `message` and bot `response`.
+- `intent`, response time, optional feedback label and metadata JSON.
+- `timecreated` timestamps used for history playback and exports.
 
 ## Troubleshooting
 
-- **Widget not visible:** Confirm the plugin is enabled and the user has the `local/chatbot:use` capability. The widget is hidden for guests and maintenance layouts.
-- **JavaScript cache:** If changes to the AMD module are not reflected, purge caches from **Site administration → Development → Purge caches**.
-- **Export button hidden:** Ensure the user has `local/chatbot:export` and that the setting “Allow conversation export” remains enabled.
+- **Widget invisible:** confirm the plugin is enabled, the user has `local/chatbot:use`, the page layout allows popups and you are not logged in as guest.
+- **Launcher badge never resets:** opening the widget clears the badge and stores the state in `localStorage`. Purge browser storage if behaviour persists.
+- **AJAX errors:** check browser console; the AMD module surfaces Moodle notifications and server responses. Ensure the web service user has the required capability.
+- **Exports blank:** verify `local/chatbot_logs` contains data and the requester has `local/chatbot:export`.
 
-## Development notes
+## Post-installation checklist
 
-- Conversations are stored in `local_chatbot_logs`. Clean up records through standard Moodle DB maintenance or by truncating the table.
-- Web services are registered for AJAX usage only (see `db/services.php`).
-- Placeholder admin pages live under `local/chatbot/admin` for future expansion and currently display informative notices only.
+- ✅ Launch the widget as a standard user and confirm welcome text, suggestions and quick actions render.
+- ✅ Send a message and verify the bot response, badge counter increment (when closed) and history replay after page reload.
+- ✅ Review the `local_chatbot_logs` table entries and test HTML/CSV/JSON exports via the widget or `/local/chatbot/export.php`.
+- ✅ Visit the Site administration pages under **Local plugins → Chatbot assistant** to ensure capability restrictions and placeholder notices load.
+
+## Development and testing tips
+
+- Use `php -l` on modified PHP files or run Moodle's PHPUnit for deeper validation.
+- Run `npx grunt amd` to generate minified JS if distributing the plugin.
+- Purge caches (`php admin/cli/purge_caches.php`) after modifying Mustache, JS or CSS assets.
+- Compare styles with `local/geniai/styles.css` if you need to align branding further.
 
 ## License
 
-This plugin is released under the GNU General Public License v3 or later.
+GPL v3 or later. See Moodle's standard license text for details.

--- a/local/chatbot/amd/src/chatbot.js
+++ b/local/chatbot/amd/src/chatbot.js
@@ -46,6 +46,15 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
     };
 
     /**
+     * Return the current timestamp in seconds.
+     *
+     * @return {number}
+     */
+    const nowInSeconds = function() {
+        return Math.floor(Date.now() / 1000);
+    };
+
+    /**
      * Controller class for the floating widget.
      */
     class ChatbotWidget {
@@ -173,7 +182,7 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                 this.$input.val(message.slice(0, this.maxlength));
             }
 
-            this.addMessage('user', message);
+            this.addMessage('user', message, {timestamp: nowInSeconds()});
             this.$input.val('').trigger('input');
             this.showTyping();
 
@@ -192,13 +201,16 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                         intent: response.intent,
                         logid: response.logid,
                         responseTime: response.response_time,
+                        timestamp: response.timestamp,
                     });
                     self.renderSuggestions(response.suggestions || []);
                     self.renderQuickActions(response.actions || []);
                 },
                 fail: function(error) {
                     self.hideTyping();
-                    self.addMessage('bot', self.config.strings.error || 'There was an error.');
+                    self.addMessage('bot', self.config.strings.error || 'There was an error.', {
+                        timestamp: nowInSeconds()
+                    });
                     Notification.exception(error);
                 },
             }]);
@@ -219,7 +231,7 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                 },
                 done: function(response) {
                     if (response.message) {
-                        self.addMessage('bot', response.message);
+                        self.addMessage('bot', response.message, {timestamp: nowInSeconds()});
                     }
                 },
                 fail: Notification.exception,
@@ -339,32 +351,32 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
          */
         addMessage(sender, text, metadata) {
             metadata = metadata || {};
-            
+
             const messageWrapper = createElement('<div class="chatbot-message chatbot-message-' + sender + '"></div>');
-            
+
             if (sender === 'bot') {
                 const avatar = createElement('<div class="message-avatar bot-avatar"><span>🤖</span></div>');
                 messageWrapper.append(avatar);
             }
-            
+
             const contentWrapper = createElement('<div class="message-content-wrapper"></div>');
-            
+
             if (sender === 'user') {
                 const header = createElement('<div class="message-header"></div>');
                 header.append('<span class="message-sender">' + this.config.username + '</span>');
-                header.append('<span class="message-time">' + formatTime(Date.now() / 1000) + '</span>');
+                header.append('<span class="message-time">' + this.getMessageTime(metadata) + '</span>');
                 contentWrapper.append(header);
             }
-            
+
             const content = createElement('<div class="message-content"></div>');
             content.text(text);
             contentWrapper.append(content);
-            
+
             if (sender === 'bot' && metadata.intent) {
                 const intent = createElement('<div class="message-intent">Intent: ' + metadata.intent + '</div>');
                 contentWrapper.append(intent);
             }
-            
+
             if (sender === 'bot' && metadata.logid) {
                 const feedback = createElement('<div class="message-feedback" data-logid="' + metadata.logid + '"></div>');
                 feedback.html(
@@ -374,18 +386,22 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                 );
                 contentWrapper.append(feedback);
             }
-            
+
             if (sender === 'user') {
-                const avatar = createElement('<div class="message-avatar user-avatar"><span>' + 
+                const avatar = createElement('<div class="message-avatar user-avatar"><span>' +
                     this.config.avatar + '</span></div>');
                 messageWrapper.append(contentWrapper);
                 messageWrapper.append(avatar);
             } else {
                 messageWrapper.append(contentWrapper);
             }
-            
+
             this.$messages.append(messageWrapper);
             this.scrollToBottom();
+
+            if (sender === 'bot' && !this.isOpen && !metadata.history) {
+                this.incrementBadge();
+            }
         }
         
         /**
@@ -407,32 +423,43 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
          * Scroll messages to bottom.
          */
         scrollToBottom() {
+            if (!this.$messages.length) {
+                return;
+            }
             const messages = this.$messages[0];
-            messages.scrollTop = messages.scrollHeight;
+            if (messages) {
+                messages.scrollTop = messages.scrollHeight;
+            }
         }
         
         /**
          * Update character count display.
          */
         updateCharCount() {
-            const current = this.$input.val().length;
+            const current = this.$input.length ? this.$input.val().length : 0;
             const $current = $('#char-current');
             const $charcount = this.$charcount;
-            
+
             $current.text(current);
-            
+
             if (current > this.maxlength * 0.9) {
                 $charcount.addClass('warning');
             } else {
                 $charcount.removeClass('warning');
             }
         }
-        
+
         /**
          * Auto-resize textarea based on content.
          */
         autoResizeTextarea() {
+            if (!this.$input.length) {
+                return;
+            }
             const textarea = this.$input[0];
+            if (!textarea) {
+                return;
+            }
             textarea.style.height = 'auto';
             textarea.style.height = Math.min(textarea.scrollHeight, 120) + 'px';
         }
@@ -441,16 +468,15 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
          * Restore launcher state from localStorage.
          */
         restoreLauncherState() {
-            if (!window.localStorage) {
-                return;
+            let state = null;
+            if (window.localStorage) {
+                state = localStorage.getItem(this.config.storagekey);
             }
-            
-            const state = localStorage.getItem(this.config.storagekey);
+
             if (state === 'open') {
                 this.open();
             }
-            
-            // Show widget after initialization.
+
             this.$container.show();
         }
         
@@ -473,8 +499,8 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
             this.$container.addClass('chatbot-active');
             this.$widget.attr('aria-hidden', 'false');
             this.$input.focus();
-            this.$badge.attr('data-count', '0');
-            
+            this.resetBadge();
+
             if (window.localStorage) {
                 localStorage.setItem(this.config.storagekey, 'open');
             }
@@ -487,22 +513,30 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
             this.isOpen = false;
             this.$container.removeClass('chatbot-active');
             this.$widget.attr('aria-hidden', 'true');
-            
+
             if (window.localStorage) {
                 localStorage.setItem(this.config.storagekey, 'closed');
             }
         }
-        
+
         /**
          * Add welcome message if first visit.
          */
         addWelcomeMessage() {
-            const welcomeShown = sessionStorage.getItem('chatbot_welcome_shown');
-            if (!welcomeShown) {
-                const welcomeText = $('#local-chatbot-welcome').val();
-                if (welcomeText) {
-                    const parsedWelcome = welcomeText.replace('{name}', this.config.username);
-                    this.addMessage('bot', parsedWelcome);
+            let welcomeShown = false;
+            if (window.sessionStorage) {
+                welcomeShown = sessionStorage.getItem('chatbot_welcome_shown') === 'true';
+            }
+
+            if (welcomeShown) {
+                return;
+            }
+
+            const welcomeText = $('#local-chatbot-welcome').val();
+            if (welcomeText) {
+                const parsedWelcome = welcomeText.replace('{name}', this.config.username);
+                this.addMessage('bot', parsedWelcome, {history: true});
+                if (window.sessionStorage) {
                     sessionStorage.setItem('chatbot_welcome_shown', 'true');
                 }
             }
@@ -525,8 +559,13 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                         self.$messages.prepend(separator);
                         
                         history.forEach(function(item) {
-                            self.addMessage('user', item.message);
-                            self.addMessage('bot', item.response, {intent: item.intent});
+                            const metadata = {timestamp: item.timestamp, history: true};
+                            self.addMessage('user', item.message, metadata);
+                            self.addMessage('bot', item.response, {
+                                intent: item.intent,
+                                timestamp: item.timestamp,
+                                history: true
+                            });
                         });
                     }
                 },
@@ -534,6 +573,43 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                     // Silently fail if history cannot be loaded.
                 }
             }]);
+        }
+
+        /**
+         * Return formatted message time.
+         *
+         * @param {Object} metadata
+         * @return {string}
+         */
+        getMessageTime(metadata) {
+            const timestamp = metadata.timestamp || nowInSeconds();
+            return formatTime(timestamp);
+        }
+
+        /**
+         * Increase launcher badge count.
+         */
+        incrementBadge() {
+            if (!this.$badge.length) {
+                return;
+            }
+            const current = parseInt(this.$badge.attr('data-count') || this.$badge.text() || '0', 10);
+            const next = current + 1;
+            this.$badge.attr('data-count', next);
+            this.$badge.text(next);
+            this.$badge.attr('aria-hidden', next ? 'false' : 'true');
+        }
+
+        /**
+         * Reset launcher badge state.
+         */
+        resetBadge() {
+            if (!this.$badge.length) {
+                return;
+            }
+            this.$badge.attr('data-count', '0');
+            this.$badge.text('0');
+            this.$badge.attr('aria-hidden', 'true');
         }
     }
     

--- a/local/chatbot/db/hooks.php
+++ b/local/chatbot/db/hooks.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$callbacks = [
+return [
     [
-        'hook' => '\core\hook\output\before_footer_html_generation',
+        'hook' => \core\hook\output\before_footer_html_generation::class,
         'callback' => 'local_chatbot_before_footer_html_generation',
         'priority' => 100,
     ],

--- a/local/chatbot/db/upgrade.php
+++ b/local/chatbot/db/upgrade.php
@@ -62,5 +62,14 @@ function xmldb_local_chatbot_upgrade(int $oldversion): bool {
         upgrade_plugin_savepoint(true, 2024052400, 'local', 'chatbot');
     }
 
+    if ($oldversion < 2025012503) {
+        if (get_config('local_chatbot', 'enabled') === null) {
+            set_config('enabled', 1, 'local_chatbot');
+        }
+
+        upgrade_plugin_savepoint(true, 2025012503, 'local', 'chatbot');
+    }
+
     return true;
 }
+

--- a/local/chatbot/externallib.php
+++ b/local/chatbot/externallib.php
@@ -92,6 +92,7 @@ class local_chatbot_external extends external_api {
             'sessionid' => $result['sessionid'],
             'intent' => $result['intent'],
             'logid' => $result['logid'],
+            'timestamp' => $result['timestamp'],
             'suggestions' => $suggestions,
             'actions' => $actions,
         ];
@@ -109,6 +110,7 @@ class local_chatbot_external extends external_api {
             'sessionid' => new external_value(PARAM_TEXT, 'Session identifier'),
             'intent' => new external_value(PARAM_TEXT, 'Matched intent'),
             'logid' => new external_value(PARAM_INT, 'Log identifier'),
+            'timestamp' => new external_value(PARAM_INT, 'Creation time'),
             'suggestions' => new external_multiple_structure(new external_single_structure([
                 'text' => new external_value(PARAM_TEXT, 'Suggestion text'),
                 'action' => new external_value(PARAM_TEXT, 'Action key'),

--- a/local/chatbot/lib.php
+++ b/local/chatbot/lib.php
@@ -24,6 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+use core\hook\output\before_footer_html_generation;
+
 require_once($CFG->dirroot . '/user/lib.php');
 
 /**
@@ -35,8 +37,10 @@ function local_chatbot_extend_navigation() {
 
 /**
  * Hook callback executed before the footer is rendered.
+ *
+ * @param before_footer_html_generation $hook
  */
-function local_chatbot_before_footer_html_generation(): void {
+function local_chatbot_before_footer_html_generation(before_footer_html_generation $hook): void {
     global $PAGE, $OUTPUT;
 
     $data = local_chatbot_get_widget_bootstrap();
@@ -47,12 +51,9 @@ function local_chatbot_before_footer_html_generation(): void {
     [$templatecontext, $jsconfig] = $data;
 
     $PAGE->requires->css('/local/chatbot/styles.css');
-    // Load the unminified AMD module explicitly so the plugin can operate without
-    // shipping the compiled chatbot.min.js asset.
-    $PAGE->requires->js(new moodle_url('/local/chatbot/amd/src/chatbot.js'), true);
     $PAGE->requires->js_call_amd('local_chatbot/chatbot', 'init', [$jsconfig]);
 
-    echo $OUTPUT->render_from_template('local_chatbot/widget', $templatecontext);
+    $hook->add_html($OUTPUT->render_from_template('local_chatbot/widget', $templatecontext));
 }
 
 /**
@@ -79,7 +80,11 @@ function local_chatbot_get_widget_bootstrap(): ?array {
         return null;
     }
 
-    if (!get_config('local_chatbot', 'enabled')) {
+    $enabled = get_config('local_chatbot', 'enabled');
+    if ($enabled === null) {
+        $enabled = true;
+    }
+    if (!$enabled) {
         $cached = null;
         return null;
     }
@@ -267,6 +272,7 @@ function local_chatbot_process_message(string $message, ?string $sessionid = nul
         'sessionid' => $sessionid,
         'intent' => $intent,
         'logid' => $logid,
+        'timestamp' => $record->timecreated,
     ];
 }
 
@@ -362,10 +368,13 @@ function local_chatbot_export_conversation(string $sessionid, string $format = '
     if ($format === 'csv') {
         $lines = ["time;sender;message;response;intent;feedback"];
         foreach ($history as $item) {
+            $user = core_user::get_user($item->userid);
+            $username = $user ? fullname($user) : get_string('deleteduser', 'core');
+
             $lines[] = sprintf(
                 '%s;%s;%s;%s;%s;%s',
                 userdate($item->timecreated),
-                fullname(core_user::get_user($item->userid)),
+                $username,
                 str_replace(['"', "\n"], ['""', ' '], $item->message),
                 str_replace(['"', "\n"], ['""', ' '], $item->response),
                 $item->intent,
@@ -390,9 +399,12 @@ function local_chatbot_export_conversation(string $sessionid, string $format = '
     $html .= html_writer::start_tag('tbody');
 
     foreach ($history as $item) {
+        $user = core_user::get_user($item->userid);
+        $username = $user ? fullname($user) : get_string('deleteduser', 'core');
+
         $html .= html_writer::tag('tr',
             html_writer::tag('td', userdate($item->timecreated)) .
-            html_writer::tag('td', fullname(core_user::get_user($item->userid))) .
+            html_writer::tag('td', $username) .
             html_writer::tag('td', format_text($item->message, FORMAT_PLAIN)) .
             html_writer::tag('td', format_text($item->response, FORMAT_PLAIN)) .
             html_writer::tag('td', s($item->intent)) .

--- a/local/chatbot/version.php
+++ b/local/chatbot/version.php
@@ -25,7 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_chatbot';
-$plugin->version   = 2025012502;
+$plugin->version   = 2025012503;
 $plugin->requires  = 2023100900; // Moodle 4.3.
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.0.0';
+$plugin->release   = '1.0.1';
+


### PR DESCRIPTION
## Summary
- switch the chatbot injection to the Moodle before_footer_html_generation hook, ensure the hook definition is returned so Moodle registers the callback, and default the widget to enabled
- refresh the AMD widget with timestamp-aware history, badge notifications, and resilient storage handling
- update exports and docs, guarding against missing users and documenting installation, upgrade and validation steps

## Testing
- php -l local/chatbot/db/hooks.php

------
https://chatgpt.com/codex/tasks/task_e_68d6d32c9b48832a8398b5391df27457