### PR TITLE
Add comprehensive administration tooling to local_chatbot

### DIFF
--- a/local/chatbot/CHANGELOG.md
+++ b/local/chatbot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.0 - 2025-02-01
+- Reemplazadas todas las pantallas administrativas provisionales por consolas completas de intenciones, entidades, entrenamiento, analíticas, visor de diálogos y pruebas manuales (`admin/*`).
+- Añadidas las tablas `local_chatbot_intents`, `local_chatbot_suggestions` y `local_chatbot_quickacts` junto con formularios de gestión y semillas iniciales (`db/install.xml`, `db/upgrade.php`).
+- El clasificador de mensajes ahora consume las intenciones configuradas y almacena la palabra clave coincidente en los metadatos (`lib.php`).
+- Sugerencias y accesos rápidos pasan a ser totalmente configurables y se exponen mediante los servicios web y el módulo AMD actualizados (`lib.php`, `externallib.php`, `amd/src/chatbot.js`).
+- Nuevo tablero de analíticas con gráficos y métricas, visor de conversaciones con filtros y exportación directa (`admin/analytics.php`, `admin/dialogues.php`).
+- Documentación y traducciones renovadas para reflejar la administración ampliada del plugin (`README.md`, `lang/*`).
+
 ## 1.0.1 - 2025-02-15
 - Convert the widget injector to the Moodle `before_footer_html_generation` hook API and stop echoing output directly (`lib.php`, `db/hooks.php`).
 - Return the hook definition array so Moodle registers the widget callback reliably (`db/hooks.php`).

--- a/local/chatbot/README.md
+++ b/local/chatbot/README.md
@@ -1,109 +1,128 @@
 # Moodle local_chatbot
 
-`local_chatbot` adds a floating assistant to Moodle pages that mirrors the positioning and look & feel of the `local_geniai` widget while providing a lightweight, keyword-based responder. The widget is injected through Moodle's `before_footer_html_generation` hook, uses a Mustache template for markup, an AMD module for interactivity and logs every dialogue in a dedicated database table.
+`local_chatbot` añade a Moodle un asistente flotante inspirado en el widget de `local_geniai`. El asistente se inyecta mediante el _hook_ `before_footer_html_generation`, renderiza su interfaz con una plantilla Mustache y un módulo AMD, y almacena cada diálogo en tablas dedicadas que puedes gestionar desde el área de administración del plugin.
 
-## Feature highlights
+## Novedades principales
 
-- Floating launcher with badge counter and animated popup styled after `local_geniai` (`templates/widget.mustache`, `styles.css`).
-- Accessible chat surface with welcome prompt, quick actions, suggestions and typing indicator (Mustache + AMD module).
-- Keyword-driven responder with configurable welcome/fallback messaging and intent tagging (`lib.php`).
-- AJAX web services for messaging, history replay, quick actions, exports and feedback (`db/services.php`, `externallib.php`).
-- Conversation log table with HTML, CSV or JSON export (`install.xml`, `lib.php`, `export.php`).
-- Granular capabilities for usage, management and exporting plus Site administration pages for future expansion (`db/access.php`, `settings.php`, `admin/*`).
+- Lanzador flotante con contador de mensajes no leídos, animaciones y apariencia alineada con `local_geniai` (`templates/widget.mustache`, `styles.css`).
+- Superficie de conversación accesible con mensaje de bienvenida, sugerencias, accesos rápidos, indicador de escritura y contador de caracteres (Mustache + AMD).
+- Clasificador por palabras clave totalmente configurable desde la administración (tabla `local_chatbot_intents`), con intención _fallback_ y respuesta personalizada.
+- Sugerencias y accesos rápidos dinámicos administrados en las tablas `local_chatbot_suggestions` y `local_chatbot_quickacts`, incluidos soportes para acciones de navegación, mensajes prefijados y respuestas del servidor.
+- Servicios web AJAX para mensajes, historial, sugerencias, accesos rápidos, exportaciones y retroalimentación (`db/services.php`, `externallib.php`).
+- Consolas administrativas completas: gestión de intenciones, entidades, entrenamiento de mensajes, analíticas, visor de diálogos y pruebas manuales (`admin/*`).
+- Exportación HTML/CSV/JSON de conversaciones (`export.php`) y consola CLI/GUI con capacidades granuladas (`db/access.php`).
 
-## Requirements and compatibility
+## Requisitos y compatibilidad
 
-| Requirement | Minimum |
-|-------------|---------|
-| Moodle core | 4.3 (build 2023100900) |
-| PHP         | 8.0 |
-| Database    | Any Moodle supported DB (table defined in `db/install.xml`) |
+| Requisito    | Versión mínima |
+|--------------|----------------|
+| Moodle core  | 4.3 (build 2023100900) |
+| PHP          | 8.0 |
+| Base de datos | Cualquiera soportada por Moodle (tablas definidas en `db/install.xml`) |
 
-The widget is injected only for authenticated, non-guest users on layouts that allow popup notifications.
+El widget se muestra únicamente a usuarios autenticados (no invitados) y en páginas que permitan _popups_.
 
-## Installation
+## Instalación
 
-1. Copy this directory to `<moodle_root>/local/chatbot` or clone the repository inside `local/`.
-2. From the Moodle web UI or CLI run the upgrade step (`php admin/cli/upgrade.php`).
-3. (Optional) Purge caches after installation (`php admin/cli/purge_caches.php`).
-4. Run Moodle cron so caches are rebuilt (`php admin/cli/cron.php`).
+1. Copia este directorio en `<moodle_root>/local/chatbot` o clona el repositorio dentro de `local/`.
+2. Desde la interfaz de Moodle o la CLI ejecuta el _upgrade_ (`php admin/cli/upgrade.php`).
+3. (Opcional) Purga cachés (`php admin/cli/purge_caches.php`).
+4. Ejecuta el cron de Moodle (`php admin/cli/cron.php`) para reconstruir cachés.
 
-The AMD controller is loaded directly from `amd/src/chatbot.js`; no additional build step is required for production. If you prefer minified assets, run `npx grunt amd`.
+El módulo AMD se carga directamente desde `amd/src/chatbot.js`; no es obligatorio generar _builds_ minimizadas (puedes hacerlo con `npx grunt amd`).
 
-## Upgrading
+## Actualizaciones
 
-- Version 1.0.1 introduces the badge counter, timestamp propagation, stronger hook integration and ensures the widget defaults to enabled. During upgrade a default `enabled` config value is created when missing (`db/upgrade.php`).
-- After replacing the plugin directory, repeat the installation steps above. Moodle will apply outstanding database or configuration upgrades automatically.
+- **1.1.0 (2025-02-01)**: incorpora tablas para intenciones, sugerencias y accesos rápidos gestionables desde la administración; reemplaza las pantallas provisionales por consolas completas; añade tablero de analíticas, visor de diálogos, consola de entrenamiento y pruebas; actualiza servicios web y el widget para consumir la configuración dinámica.
+- **1.0.1 (2025-02-15)**: adapta la inyección del widget al _hook_ oficial, añade contador de mensajes y asegura que el plugin quede habilitado tras la actualización.
 
-## Configuration
+Después de sustituir el directorio del plugin, repite los pasos de instalación. Moodle aplicará automáticamente los cambios de base de datos y configuración pendientes.
 
-Navigate to **Site administration → Plugins → Local plugins → Chatbot assistant** (`settings.php`) to manage:
+## Configuración
 
-- Enable chatbot (defaults to on).
-- Assistant name shown in the header and aria labels.
-- Launcher position (bottom-right or bottom-left).
-- Theme palette (modern, minimal, dark).
-- Welcome message template supporting `{name}` token replacement.
-- Fallback response when no keyword is matched.
-- Maximum message length enforced in the UI.
-- Toggle for exposing the export button (requires `local/chatbot:export`).
+### Ajustes generales
 
-## Capabilities
+Visita **Administración del sitio → Plugins → Plugins locales → Asistente de chatbot** (`settings.php`) para controlar:
 
-| Capability | Purpose | Default roles |
-|------------|---------|----------------|
-| `local/chatbot:use` | Launch the widget and call web services | Authenticated users |
-| `local/chatbot:manage` | Access placeholder admin consoles | Manager |
-| `local/chatbot:export` | Export chat history | Authenticated users |
+- Activar o desactivar el chatbot.
+- Nombre del asistente (se muestra en el encabezado y textos accesibles).
+- Posición del lanzador (esquina inferior derecha o izquierda).
+- Paleta de colores (moderno, minimalista u oscuro).
+- Mensaje de bienvenida con soporte para el token `{name}`.
+- Mensaje por defecto cuando no hay coincidencias.
+- Longitud máxima del mensaje en la interfaz.
+- Visibilidad del botón de exportar (requiere el permiso `local/chatbot:export`).
 
-## Widget behaviour and assets
+### Consolas específicas
 
-- HTML is rendered from `templates/widget.mustache`, replicating `local_geniai` launcher/header layout and ARIA labelling.
-- Styling lives in `styles.css` with responsive rules that mirror the reference plugin.
-- `amd/src/chatbot.js` boots the widget, talks to web services, shows history, updates the launcher badge when new bot replies arrive and honours local/session storage for persistence.
-- Server bootstrap (`lib.php`) injects CSS/JS, builds the template context, enforces capabilities and passes localisation strings plus runtime config to the AMD module.
+El plugin añade una categoría propia en **Administración del sitio → Plugins → Plugins locales → Asistente de chatbot** con las siguientes páginas:
 
-## Web services
+| Página | Descripción |
+|--------|-------------|
+| **Gestionar intenciones** | Crea, edita y elimina intenciones, palabras clave y la intención _fallback_. |
+| **Gestionar entidades** | Administra accesos rápidos (navegación, inyección o respuesta del servidor) y sugerencias mostradas en el widget. |
+| **Entrenamiento y aprendizaje** | Analiza mensajes, comprueba coincidencias y (opcionalmente) registra el resultado en el historial. |
+| **Analíticas e informes** | Muestra métricas clave, gráficos de uso por intención, actividad diaria y distribución de feedback. |
+| **Flujos de diálogo** | Lista, filtra y detalla sesiones con posibilidad de exportar la conversación seleccionada. |
+| **Probar el chatbot** | Envía mensajes manualmente para verificar respuestas y revisar el historial de una sesión concreta. |
 
-All services are defined in `db/services.php` and implemented in `externallib.php`:
+## Capacidades
 
-- `local_chatbot_process_message`: keyword response, intent tagging, quick actions & suggestions.
-- `local_chatbot_get_history`: returns the latest messages with timestamps for replay.
-- `local_chatbot_get_suggestions`: contextual prompt suggestions.
-- `local_chatbot_get_quick_actions`: shortcut buttons (profile, calendar, etc.).
-- `local_chatbot_export_conversation`: server-side HTML/CSV/JSON export used by the widget and standalone export page.
-- `local_chatbot_feedback`: stores thumbs-up/down feedback on each log entry.
-- `local_chatbot_execute_action`: executes quick action shortcuts (placeholder).
+| Capacidad | Propósito | Roles por defecto |
+|-----------|-----------|-------------------|
+| `local/chatbot:use` | Mostrar el widget y consumir servicios web | Usuarios autenticados |
+| `local/chatbot:manage` | Acceder a las consolas administrativas | Gestor |
+| `local/chatbot:export` | Exportar historial de conversaciones | Usuarios autenticados |
 
-## Data storage
+## Funcionamiento del widget
 
-The plugin creates `local_chatbot_logs` (`db/install.xml`) capturing:
+- El HTML se genera con `templates/widget.mustache`, replicando la estructura y etiquetado ARIA del widget de `local_geniai`.
+- Los estilos (`styles.css`) se encargan del aspecto flotante, animaciones y adaptabilidad.
+- `amd/src/chatbot.js` inicializa el widget, consume los servicios AJAX, restaura el historial, gestiona el contador del lanzador y conserva la apertura/cierre usando `localStorage` y `sessionStorage`.
+- `lib.php` controla la inyección del widget, construye el contexto Mustache, obtiene la configuración dinámica (intenciones, sugerencias y accesos rápidos), valida permisos y expone la configuración al módulo AMD.
 
-- `userid`, `sessionid`, original `message` and bot `response`.
-- `intent`, response time, optional feedback label and metadata JSON.
-- `timecreated` timestamps used for history playback and exports.
+## Servicios web
 
-## Troubleshooting
+Los servicios definidos en `db/services.php` y desarrollados en `externallib.php` permiten al widget:
 
-- **Widget invisible:** confirm the plugin is enabled, the user has `local/chatbot:use`, the page layout allows popups and you are not logged in as guest.
-- **Launcher badge never resets:** opening the widget clears the badge and stores the state in `localStorage`. Purge browser storage if behaviour persists.
-- **AJAX errors:** check browser console; the AMD module surfaces Moodle notifications and server responses. Ensure the web service user has the required capability.
-- **Exports blank:** verify `local/chatbot_logs` contains data and the requester has `local/chatbot:export`.
+- Procesar mensajes (`local_chatbot_process_message`).
+- Recuperar historial (`local_chatbot_get_history`).
+- Obtener sugerencias dinámicas (`local_chatbot_get_suggestions`).
+- Recuperar accesos rápidos gestionables (`local_chatbot_get_quick_actions`).
+- Exportar conversaciones (`local_chatbot_export_conversation`).
+- Guardar retroalimentación (`local_chatbot_feedback`).
+- Ejecutar accesos rápidos del lado servidor (`local_chatbot_execute_action`).
 
-## Post-installation checklist
+## Almacenamiento de datos
 
-- ✅ Launch the widget as a standard user and confirm welcome text, suggestions and quick actions render.
-- ✅ Send a message and verify the bot response, badge counter increment (when closed) and history replay after page reload.
-- ✅ Review the `local_chatbot_logs` table entries and test HTML/CSV/JSON exports via the widget or `/local/chatbot/export.php`.
-- ✅ Visit the Site administration pages under **Local plugins → Chatbot assistant** to ensure capability restrictions and placeholder notices load.
+El plugin crea las siguientes tablas (`db/install.xml`):
 
-## Development and testing tips
+- `local_chatbot_logs`: historial de mensajes, respuestas, intención, tiempos de respuesta, metadatos y feedback.
+- `local_chatbot_intents`: intenciones configurables con palabras clave, respuesta, orden y bandera de _fallback_.
+- `local_chatbot_suggestions`: sugerencias mostradas en el widget con icono, modo (mensaje/acción) y orden.
+- `local_chatbot_quickacts`: accesos rápidos con clave, tipo (navegación/inyección/servidor), carga útil, icono y orden.
 
-- Use `php -l` on modified PHP files or run Moodle's PHPUnit for deeper validation.
-- Run `npx grunt amd` to generate minified JS if distributing the plugin.
-- Purge caches (`php admin/cli/purge_caches.php`) after modifying Mustache, JS or CSS assets.
-- Compare styles with `local/geniai/styles.css` if you need to align branding further.
+## Resolución de problemas
 
-## License
+- **El widget no aparece:** verifica que el plugin esté habilitado, que el usuario tenga `local/chatbot:use`, que la página permita popups y que no sea una sesión de invitado.
+- **El contador del lanzador no se reinicia:** abrir el widget limpia el contador y guarda el estado en `localStorage`. Borra el almacenamiento del navegador si persiste.
+- **Errores AJAX:** revisa la consola del navegador; el módulo AMD muestra las excepciones. Comprueba permisos y que los servicios web estén habilitados.
+- **Exportaciones vacías:** asegúrate de que existan registros en `local_chatbot_logs` y de que quien exporta tenga `local/chatbot:export`.
 
-GPL v3 or later. See Moodle's standard license text for details.
+## Lista de verificación tras la instalación
+
+- ✅ Abre el widget con un usuario estándar y confirma que se muestran mensaje de bienvenida, sugerencias y accesos rápidos.
+- ✅ Envía un mensaje, revisa la respuesta y valida que el contador del lanzador se incrementa cuando el widget está cerrado.
+- ✅ Comprueba que la intención correcta queda registrada en `local_chatbot_logs` y prueba las exportaciones en `/local/chatbot/export.php`.
+- ✅ Recorre las páginas administrativas (intenciones, entidades, entrenamiento, analíticas, diálogos y pruebas) para confirmar que cargan y funcionan con tus datos reales.
+
+## Desarrollo y pruebas
+
+- Ejecuta `php -l` sobre los archivos PHP modificados o ejecuta PHPUnit si quieres pruebas más profundas.
+- Para distribuir el plugin con assets minimizados puedes ejecutar `npx grunt amd`.
+- Purga cachés (`php admin/cli/purge_caches.php`) tras modificar plantillas Mustache, JS o CSS.
+- Compara estilos con `local/geniai/styles.css` si necesitas alinear aún más el diseño.
+
+## Licencia
+
+GPL v3 o posterior. Consulta la licencia estándar de Moodle para más detalles.

--- a/local/chatbot/admin/analytics.php
+++ b/local/chatbot/admin/analytics.php
@@ -15,26 +15,144 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Placeholder analytics dashboard for the chatbot plugin.
+ * Analytics dashboard for the chatbot plugin.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/tablelib.php');
+require_once($CFG->libdir . '/chartlib.php');
+
+defined('MOODLE_INTERNAL') || die();
 
 admin_externalpage_setup('local_chatbot_analytics');
+require_capability('local/chatbot:manage', context_system::instance());
 
-$heading = get_string('analytics', 'local_chatbot');
-$PAGE->set_title($heading);
-$PAGE->set_heading($heading);
+$PAGE->set_title(get_string('analytics', 'local_chatbot'));
+$PAGE->set_heading(get_string('analytics', 'local_chatbot'));
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
 
-echo $OUTPUT->notification(get_string('admin_placeholder', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
-echo $OUTPUT->notification(get_string('admin_placeholder_help', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+echo $OUTPUT->heading(get_string('analytics', 'local_chatbot'));
+
+echo $OUTPUT->notification(get_string('analytics_intro', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+
+$totalmessages = $DB->count_records('local_chatbot_logs');
+$totalsessions = (int)$DB->get_field_sql('SELECT COUNT(DISTINCT sessionid) FROM {local_chatbot_logs}');
+$totalusers = (int)$DB->get_field_sql('SELECT COUNT(DISTINCT userid) FROM {local_chatbot_logs}');
+$averageresponse = (float)$DB->get_field_sql('SELECT AVG(responsetime) FROM {local_chatbot_logs}');
+
+$stats = [
+    get_string('analytics_total_messages', 'local_chatbot') => $totalmessages,
+    get_string('analytics_total_sessions', 'local_chatbot') => $totalsessions,
+    get_string('analytics_total_users', 'local_chatbot') => $totalusers,
+    get_string('analytics_average_response', 'local_chatbot') => $averageresponse ? round($averageresponse, 2) . ' ms' : '-'
+];
+
+echo html_writer::start_div('local-chatbot-analytics-stats d-flex flex-wrap gap-3 mb-4');
+foreach ($stats as $label => $value) {
+    echo html_writer::div(
+        html_writer::tag('strong', $value) . html_writer::empty_tag('br') .
+        html_writer::span($label, 'text-muted'),
+        'p-3 border rounded'
+    );
+}
+
+echo html_writer::end_div();
+
+$intentrecords = $DB->get_records_sql('SELECT intent, COUNT(*) AS total FROM {local_chatbot_logs} GROUP BY intent ORDER BY total DESC');
+if ($intentrecords) {
+    echo $OUTPUT->heading(get_string('analytics_intents_heading', 'local_chatbot'), 3);
+
+    $table = new flexible_table('local-chatbot-analytics-intents');
+    $table->define_columns(['intent', 'total']);
+    $table->define_headers([get_string('intent', 'local_chatbot'), get_string('analytics_messages', 'local_chatbot')]);
+    $table->set_attribute('class', 'generaltable generalbox');
+    $table->setup();
+
+    $chart = new core\chart_bar();
+    $series = new core\chart_series(get_string('analytics_messages', 'local_chatbot'));
+    $labels = [];
+    $values = [];
+
+    foreach ($intentrecords as $record) {
+        $table->add_data([format_string($record->intent ?: get_string('intent_unknown', 'local_chatbot')), (int)$record->total]);
+        $labels[] = $record->intent ?: get_string('intent_unknown', 'local_chatbot');
+        $values[] = (int)$record->total;
+    }
+
+    $table->finish_output();
+
+    $series->set_data($values);
+    $chart->add_series($series);
+    $chart->set_labels($labels);
+    $chart->set_title(get_string('analytics_intents_chart_title', 'local_chatbot'));
+
+    echo $OUTPUT->render($chart);
+}
+
+$days = 14;
+$cutoff = time() - ($days - 1) * DAYSECS;
+$labels = [];
+$values = [];
+$dailycounts = [];
+$records = $DB->get_records_select('local_chatbot_logs', 'timecreated >= ?', [$cutoff], 'timecreated ASC', 'timecreated');
+foreach ($records as $record) {
+    $day = date('Y-m-d', (int)$record->timecreated);
+    if (!isset($dailycounts[$day])) {
+        $dailycounts[$day] = 0;
+    }
+    $dailycounts[$day]++;
+}
+
+for ($i = $days - 1; $i >= 0; $i--) {
+    $date = date('Y-m-d', time() - $i * DAYSECS);
+    $labels[] = $date;
+    $values[] = $dailycounts[$date] ?? 0;
+}
+
+$activitychart = new core\chart_line();
+$activityseries = new core\chart_series(get_string('analytics_messages', 'local_chatbot'), $values);
+$activitychart->add_series($activityseries);
+$activitychart->set_labels($labels);
+$activitychart->set_title(get_string('analytics_activity_chart_title', 'local_chatbot'));
+
+if (array_sum($values) > 0) {
+    echo $OUTPUT->heading(get_string('analytics_activity_heading', 'local_chatbot'), 3);
+    echo $OUTPUT->render($activitychart);
+}
+
+$feedbackrecords = $DB->get_records_sql("SELECT feedback, COUNT(*) AS total
+    FROM {local_chatbot_logs}
+    WHERE feedback IS NOT NULL AND feedback <> ''
+    GROUP BY feedback");
+if ($feedbackrecords) {
+    echo $OUTPUT->heading(get_string('analytics_feedback_heading', 'local_chatbot'), 3);
+    $table = new flexible_table('local-chatbot-analytics-feedback');
+    $table->define_columns(['label', 'total']);
+    $table->define_headers([get_string('feedback', 'local_chatbot'), get_string('analytics_messages', 'local_chatbot')]);
+    $table->set_attribute('class', 'generaltable generalbox');
+    $table->setup();
+
+    $feedbackchart = new core\chart_pie();
+    $pievalues = [];
+    $pielabels = [];
+
+    foreach ($feedbackrecords as $record) {
+        $label = $record->feedback ?: get_string('analytics_feedback_unknown', 'local_chatbot');
+        $table->add_data([format_string($label), (int)$record->total]);
+        $pielabels[] = $label;
+        $pievalues[] = (int)$record->total;
+    }
+
+    $table->finish_output();
+
+    $feedbackchart->add_series(new core\chart_series(get_string('analytics_messages', 'local_chatbot'), $pievalues));
+    $feedbackchart->set_labels($pielabels);
+
+    echo $OUTPUT->render($feedbackchart);
+}
 
 echo $OUTPUT->footer();

--- a/local/chatbot/admin/dialogues.php
+++ b/local/chatbot/admin/dialogues.php
@@ -15,26 +15,199 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Placeholder administration page for multi-turn dialogues.
+ * Dialogue log viewer for the chatbot plugin.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/tablelib.php');
+require_once($CFG->dirroot . '/user/lib.php');
+
+use local_chatbot\form\dialogue_filter_form;
+
+defined('MOODLE_INTERNAL') || die();
+
+class local_chatbot_dialogue_table extends table_sql {
+    /**
+     * Format user column.
+     *
+     * @param stdClass $row
+     * @return string
+     */
+    public function col_user($row): string {
+        if (!empty($row->userid)) {
+            $user = core_user::get_user($row->userid, 'id, firstname, lastname, email', IGNORE_MISSING);
+            if ($user) {
+                $name = fullname($user);
+                return html_writer::link(new moodle_url('/user/profile.php', ['id' => $user->id]), format_string($name));
+            }
+        }
+        return get_string('deleteduser', 'core');
+    }
+
+    /**
+     * Format message column with preview.
+     *
+     * @param stdClass $row
+     * @return string
+     */
+    public function col_message($row): string {
+        return format_text(shorten_text($row->message, 120), FORMAT_PLAIN);
+    }
+
+    /**
+     * Format time column.
+     *
+     * @param stdClass $row
+     * @return string
+     */
+    public function col_timecreated($row): string {
+        return userdate($row->timecreated);
+    }
+
+    /**
+     * Format actions column.
+     *
+     * @param stdClass $row
+     * @return string
+     */
+    public function col_actions($row): string {
+        $detailurl = new moodle_url($this->baseurl);
+        $detailurl->param('detail', $row->sessionid);
+        return html_writer::link($detailurl, get_string('viewdetails', 'local_chatbot'));
+    }
+}
 
 admin_externalpage_setup('local_chatbot_dialogues');
+require_capability('local/chatbot:manage', context_system::instance());
 
-$heading = get_string('dialogues', 'local_chatbot');
-$PAGE->set_title($heading);
-$PAGE->set_heading($heading);
+$baseurl = new moodle_url('/local/chatbot/admin/dialogues.php');
+$detail = optional_param('detail', '', PARAM_ALPHANUMEXT);
+
+$filters = [
+    'sessionid' => optional_param('sessionid', '', PARAM_ALPHANUMEXT),
+    'userid' => optional_param('userid', 0, PARAM_INT),
+    'intent' => optional_param('intent', '', PARAM_TEXT),
+    'from' => optional_param('from', 0, PARAM_INT),
+    'to' => optional_param('to', 0, PARAM_INT),
+    'hasfeedback' => optional_param('hasfeedback', 0, PARAM_BOOL),
+];
+
+if (optional_param('resetbutton', '', PARAM_TEXT)) {
+    redirect($baseurl);
+}
+
+$intentoptions = ['' => get_string('all')];
+$intents = $DB->get_records('local_chatbot_intents', null, 'name ASC', 'name');
+foreach ($intents as $intent) {
+    $intentoptions[$intent->name] = format_string($intent->name);
+}
+
+$form = new dialogue_filter_form($baseurl, ['intents' => $intentoptions]);
+$form->set_data((object)$filters);
+
+if ($data = $form->get_data()) {
+    $params = [];
+    foreach ($filters as $key => $value) {
+        if (!empty($data->$key)) {
+            $params[$key] = $data->$key;
+        }
+    }
+    redirect(new moodle_url($baseurl, $params));
+}
+
+$PAGE->set_url(new moodle_url($baseurl, array_filter($filters)));
+$PAGE->set_title(get_string('dialogues', 'local_chatbot'));
+$PAGE->set_heading(get_string('dialogues', 'local_chatbot'));
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
 
-echo $OUTPUT->notification(get_string('admin_placeholder', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
-echo $OUTPUT->notification(get_string('admin_placeholder_help', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+echo $OUTPUT->heading(get_string('dialogues', 'local_chatbot'));
+
+$form->display();
+
+if ($detail) {
+    $entries = $DB->get_records('local_chatbot_logs', ['sessionid' => $detail], 'timecreated ASC');
+    if ($entries) {
+        echo $OUTPUT->heading(get_string('dialogue_detail_heading', 'local_chatbot', $detail), 3);
+        $items = [];
+        foreach ($entries as $entry) {
+            $message = format_text($entry->message, FORMAT_PLAIN);
+            $response = format_text($entry->response, FORMAT_PLAIN);
+            $intent = format_string($entry->intent ?? '');
+            $feedback = $entry->feedback ? format_string($entry->feedback) : '';
+            $items[] = html_writer::tag('div',
+                html_writer::tag('h5', userdate($entry->timecreated)) .
+                html_writer::tag('p', html_writer::span(get_string('message', 'local_chatbot') . ': ' . $message)) .
+                html_writer::tag('p', html_writer::span(get_string('response', 'local_chatbot') . ': ' . $response)) .
+                html_writer::tag('p', html_writer::span(get_string('intent', 'local_chatbot') . ': ' . $intent)) .
+                ($feedback ? html_writer::tag('p', get_string('feedback', 'local_chatbot') . ': ' . $feedback) : ''),
+                ['class' => 'p-3 border rounded mb-3']
+            );
+        }
+        echo implode('', $items);
+
+        $exporturl = new moodle_url('/local/chatbot/export.php', ['sessionid' => $detail]);
+        echo html_writer::div(html_writer::link($exporturl, get_string('dialogue_export', 'local_chatbot'),
+            ['class' => 'btn btn-secondary']), 'mb-4');
+    } else {
+        echo $OUTPUT->notification(get_string('dialogue_no_records', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+    }
+}
+
+$where = [];
+$params = [];
+
+if ($filters['sessionid']) {
+    $where[] = 'l.sessionid = :fsessionid';
+    $params['fsessionid'] = $filters['sessionid'];
+}
+if (!empty($filters['userid'])) {
+    $where[] = 'l.userid = :fuserid';
+    $params['fuserid'] = $filters['userid'];
+}
+if ($filters['intent']) {
+    $where[] = 'l.intent = :fintent';
+    $params['fintent'] = $filters['intent'];
+}
+if (!empty($filters['from'])) {
+    $where[] = 'l.timecreated >= :ffrom';
+    $params['ffrom'] = $filters['from'];
+}
+if (!empty($filters['to'])) {
+    $where[] = 'l.timecreated <= :fto';
+    $params['fto'] = $filters['to'] + DAYSECS - 1;
+}
+if (!empty($filters['hasfeedback'])) {
+    $where[] = "(l.feedback IS NOT NULL AND l.feedback <> '')";
+}
+
+$wheresql = $where ? implode(' AND ', $where) : '1=1';
+
+$table = new local_chatbot_dialogue_table('local-chatbot-dialogues');
+$table->set_attribute('class', 'generaltable generalbox local-chatbot-dialogues-table');
+$table->define_columns(['sessionid', 'user', 'intent', 'message', 'timecreated', 'feedback', 'actions']);
+$table->define_headers([
+    get_string('dialogue_session', 'local_chatbot'),
+    get_string('user'),
+    get_string('intent', 'local_chatbot'),
+    get_string('message', 'local_chatbot'),
+    get_string('time'),
+    get_string('feedback', 'local_chatbot'),
+    get_string('actions'),
+]);
+$table->sortable(true, 'timecreated', SORT_DESC);
+$tablebaseurl = new moodle_url('/local/chatbot/admin/dialogues.php', array_filter($filters));
+$table->define_baseurl($tablebaseurl);
+$table->set_sql(
+    'l.id, l.sessionid, l.userid, l.message, l.intent, l.timecreated, l.feedback',
+    "{local_chatbot_logs} l",
+    $wheresql,
+    $params
+);
+
+$table->out(20, true);
 
 echo $OUTPUT->footer();

--- a/local/chatbot/admin/entities.php
+++ b/local/chatbot/admin/entities.php
@@ -15,31 +15,255 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Placeholder administration page for managing chatbot entities.
+ * Administration console for chatbot entities: quick actions and suggestions.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/tablelib.php');
+
+use local_chatbot\form\quickaction_form;
+use local_chatbot\form\suggestion_form;
+
+defined('MOODLE_INTERNAL') || die();
 
 admin_externalpage_setup('local_chatbot_entities');
+require_capability('local/chatbot:manage', context_system::instance());
 
-$heading = get_string('manage_entities', 'local_chatbot');
-$PAGE->set_title($heading);
-$PAGE->set_heading($heading);
+$baseurl = new moodle_url('/local/chatbot/admin/entities.php');
+$tab = optional_param('tab', 'quickactions', PARAM_ALPHA);
+$action = optional_param('action', '', PARAM_ALPHA);
+$id = optional_param('id', 0, PARAM_INT);
+
+$tabs = [
+    new tabobject('quickactions', new moodle_url($baseurl, ['tab' => 'quickactions']),
+        get_string('entities_quickactions_tab', 'local_chatbot')),
+    new tabobject('suggestions', new moodle_url($baseurl, ['tab' => 'suggestions']),
+        get_string('entities_suggestions_tab', 'local_chatbot')),
+];
+
+$PAGE->set_title(get_string('manage_entities', 'local_chatbot'));
+$PAGE->set_heading(get_string('manage_entities', 'local_chatbot'));
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
 
-echo $OUTPUT->notification(get_string('admin_placeholder', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
-echo $OUTPUT->notification(get_string('admin_placeholder_help', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+echo $OUTPUT->heading(get_string('manage_entities', 'local_chatbot'));
 
-echo html_writer::tag('p', html_writer::link(
-    new moodle_url('/admin/settings.php', ['section' => 'local_chatbot']),
-    get_string('pluginname', 'local_chatbot')
-));
+echo $OUTPUT->tabtree($tabs, $tab);
+
+echo $OUTPUT->notification(get_string('entities_intro', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+
+if ($tab === 'quickactions') {
+    $formurl = new moodle_url($baseurl, ['tab' => 'quickactions']);
+    $current = null;
+    if ($action === 'edit' && $id) {
+        $current = $DB->get_record('local_chatbot_quickacts', ['id' => $id], '*', MUST_EXIST);
+    }
+
+    $form = new quickaction_form($formurl, ['id' => $current->id ?? 0]);
+    if ($current) {
+        $form->set_data($current);
+    }
+
+    if ($action === 'delete' && $id && confirm_sesskey()) {
+        if ($DB->record_exists('local_chatbot_quickacts', ['id' => $id])) {
+            $DB->delete_records('local_chatbot_quickacts', ['id' => $id]);
+            local_chatbot_reset_runtime_cache();
+            redirect($formurl, get_string('quickaction_deleted', 'local_chatbot'), null,
+                \core\output\notification::NOTIFY_SUCCESS);
+        }
+    }
+
+    if ($form->is_cancelled()) {
+        redirect($formurl);
+    } else if ($data = $form->get_data()) {
+        $record = (object) [
+            'actionkey' => trim((string)$data->actionkey),
+            'name' => trim((string)$data->name),
+            'type' => $data->type,
+            'payload' => trim((string)$data->payload),
+            'description' => trim((string)$data->description),
+            'icon' => trim((string)$data->icon),
+            'enabled' => empty($data->enabled) ? 0 : 1,
+            'sortorder' => (int)$data->sortorder,
+            'timemodified' => time(),
+        ];
+
+        if ($record->type === 'navigate' && $record->payload !== '') {
+            if (!preg_match('/^(https?:\/\/|\/)/', $record->payload)) {
+                $record->payload = '/' . ltrim($record->payload, '/');
+            }
+        }
+
+        if (!empty($data->id)) {
+            $record->id = $data->id;
+            $DB->update_record('local_chatbot_quickacts', $record);
+        } else {
+            $record->timecreated = time();
+            $record->id = $DB->insert_record('local_chatbot_quickacts', $record);
+        }
+
+        local_chatbot_reset_runtime_cache();
+
+        redirect($formurl, get_string('quickaction_saved', 'local_chatbot'), null,
+            \core\output\notification::NOTIFY_SUCCESS);
+    }
+
+    if ($action === 'edit') {
+        echo $OUTPUT->heading(get_string('quickaction_edit_heading', 'local_chatbot'), 3);
+    } else {
+        echo $OUTPUT->heading(get_string('quickaction_add_heading', 'local_chatbot'), 3);
+    }
+    $form->display();
+
+    echo $OUTPUT->heading(get_string('quickaction_table_heading', 'local_chatbot'), 3);
+
+    $table = new flexible_table('local-chatbot-quickactions');
+    $table->define_columns(['name', 'actionkey', 'type', 'payload', 'status', 'sortorder', 'actions']);
+    $table->define_headers([
+        get_string('quickaction_name', 'local_chatbot'),
+        get_string('quickaction_actionkey', 'local_chatbot'),
+        get_string('quickaction_type', 'local_chatbot'),
+        get_string('quickaction_payload', 'local_chatbot'),
+        get_string('quickaction_status', 'local_chatbot'),
+        get_string('quickaction_sortorder', 'local_chatbot'),
+        get_string('actions'),
+    ]);
+    $table->sortable(true, 'sortorder', SORT_ASC);
+    $table->set_attribute('class', 'generaltable generalbox local-chatbot-quickactions-table');
+    $table->setup();
+
+    $quickactions = $DB->get_records('local_chatbot_quickacts', null, 'sortorder ASC, name ASC');
+    foreach ($quickactions as $qa) {
+        $statusparts = [];
+        $statusparts[] = $qa->enabled ? get_string('enabled', 'core') : get_string('disabled', 'core');
+        $statusparts[] = get_string('quickaction_type_' . $qa->type, 'local_chatbot');
+        $status = implode(' · ', $statusparts);
+
+        $actions = [];
+        $actions[] = html_writer::link(new moodle_url($formurl, ['action' => 'edit', 'id' => $qa->id]), get_string('edit'));
+        $actions[] = html_writer::link(new moodle_url($formurl, [
+            'action' => 'delete',
+            'id' => $qa->id,
+            'sesskey' => sesskey(),
+        ]), get_string('delete'), [
+            'data-confirm' => get_string('quickaction_delete_confirm', 'local_chatbot', $qa->name),
+        ]);
+
+        $table->add_data([
+            format_string($qa->name),
+            format_string($qa->actionkey),
+            format_string($qa->type),
+            format_text($qa->payload, FORMAT_PLAIN),
+            $status,
+            (int)$qa->sortorder,
+            implode(' | ', $actions),
+        ]);
+    }
+
+    $table->finish_output();
+} else {
+    $formurl = new moodle_url($baseurl, ['tab' => 'suggestions']);
+    $current = null;
+    if ($action === 'edit' && $id) {
+        $current = $DB->get_record('local_chatbot_suggestions', ['id' => $id], '*', MUST_EXIST);
+    }
+
+    if ($action === 'delete' && $id && confirm_sesskey()) {
+        if ($DB->record_exists('local_chatbot_suggestions', ['id' => $id])) {
+            $DB->delete_records('local_chatbot_suggestions', ['id' => $id]);
+            local_chatbot_reset_runtime_cache();
+            redirect($formurl, get_string('suggestion_deleted', 'local_chatbot'), null,
+                \core\output\notification::NOTIFY_SUCCESS);
+        }
+    }
+
+    $form = new suggestion_form($formurl);
+    if ($current) {
+        $form->set_data($current);
+    }
+
+    if ($form->is_cancelled()) {
+        redirect($formurl);
+    } else if ($data = $form->get_data()) {
+        $record = (object) [
+            'text' => trim((string)$data->text),
+            'mode' => $data->mode,
+            'target' => trim((string)$data->target),
+            'icon' => trim((string)$data->icon),
+            'enabled' => empty($data->enabled) ? 0 : 1,
+            'sortorder' => (int)$data->sortorder,
+            'timemodified' => time(),
+        ];
+
+        if (!empty($data->id)) {
+            $record->id = $data->id;
+            $DB->update_record('local_chatbot_suggestions', $record);
+        } else {
+            $record->timecreated = time();
+            $record->id = $DB->insert_record('local_chatbot_suggestions', $record);
+        }
+
+        local_chatbot_reset_runtime_cache();
+
+        redirect($formurl, get_string('suggestion_saved', 'local_chatbot'), null,
+            \core\output\notification::NOTIFY_SUCCESS);
+    }
+
+    if ($action === 'edit') {
+        echo $OUTPUT->heading(get_string('suggestion_edit_heading', 'local_chatbot'), 3);
+    } else {
+        echo $OUTPUT->heading(get_string('suggestion_add_heading', 'local_chatbot'), 3);
+    }
+    $form->display();
+
+    echo $OUTPUT->heading(get_string('suggestion_table_heading', 'local_chatbot'), 3);
+
+    $table = new flexible_table('local-chatbot-suggestions');
+    $table->define_columns(['text', 'mode', 'target', 'icon', 'status', 'sortorder', 'actions']);
+    $table->define_headers([
+        get_string('suggestion_text', 'local_chatbot'),
+        get_string('suggestion_mode', 'local_chatbot'),
+        get_string('suggestion_target', 'local_chatbot'),
+        get_string('suggestion_icon', 'local_chatbot'),
+        get_string('suggestion_status', 'local_chatbot'),
+        get_string('suggestion_sortorder', 'local_chatbot'),
+        get_string('actions'),
+    ]);
+    $table->sortable(true, 'sortorder', SORT_ASC);
+    $table->set_attribute('class', 'generaltable generalbox local-chatbot-suggestions-table');
+    $table->setup();
+
+    $suggestions = $DB->get_records('local_chatbot_suggestions', null, 'sortorder ASC, text ASC');
+    foreach ($suggestions as $suggestion) {
+        $statusparts = [];
+        $statusparts[] = $suggestion->enabled ? get_string('enabled', 'core') : get_string('disabled', 'core');
+        $statusparts[] = get_string('suggestion_mode_' . $suggestion->mode, 'local_chatbot');
+
+        $actions = [];
+        $actions[] = html_writer::link(new moodle_url($formurl, ['action' => 'edit', 'id' => $suggestion->id]), get_string('edit'));
+        $actions[] = html_writer::link(new moodle_url($formurl, [
+            'action' => 'delete',
+            'id' => $suggestion->id,
+            'sesskey' => sesskey(),
+        ]), get_string('delete'), [
+            'data-confirm' => get_string('suggestion_delete_confirm', 'local_chatbot', $suggestion->text),
+        ]);
+
+        $table->add_data([
+            format_string($suggestion->text),
+            get_string('suggestion_mode_' . $suggestion->mode, 'local_chatbot'),
+            format_string($suggestion->target),
+            format_string($suggestion->icon),
+            implode(' · ', $statusparts),
+            (int)$suggestion->sortorder,
+            implode(' | ', $actions),
+        ]);
+    }
+
+    $table->finish_output();
+}
 
 echo $OUTPUT->footer();

--- a/local/chatbot/admin/intents.php
+++ b/local/chatbot/admin/intents.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Placeholder administration page for managing chatbot intents.
+ * Administration console for chatbot intents.
  *
  * @package    local_chatbot
  * @copyright  2024 Moodle Community
@@ -24,22 +24,134 @@
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/tablelib.php');
+
+use local_chatbot\form\intent_form;
+
+defined('MOODLE_INTERNAL') || die();
 
 admin_externalpage_setup('local_chatbot_intents');
 
-$heading = get_string('manage_intents', 'local_chatbot');
-$PAGE->set_title($heading);
-$PAGE->set_heading($heading);
+require_capability('local/chatbot:manage', context_system::instance());
+
+$baseurl = new moodle_url('/local/chatbot/admin/intents.php');
+$action = optional_param('action', '', PARAM_ALPHA);
+$id = optional_param('id', 0, PARAM_INT);
+
+if ($action === 'delete' && $id && confirm_sesskey()) {
+    if ($DB->record_exists('local_chatbot_intents', ['id' => $id])) {
+        $DB->delete_records('local_chatbot_intents', ['id' => $id]);
+        local_chatbot_reset_runtime_cache();
+        redirect($baseurl, get_string('intent_deleted', 'local_chatbot'), null, \core\output\notification::NOTIFY_SUCCESS);
+    }
+}
+
+$current = null;
+if ($action === 'edit' && $id) {
+    $current = $DB->get_record('local_chatbot_intents', ['id' => $id], '*', MUST_EXIST);
+}
+
+$mform = new intent_form($baseurl);
+if ($current) {
+    $mform->set_data($current);
+}
+
+if ($mform->is_cancelled()) {
+    redirect($baseurl);
+} else if ($data = $mform->get_data()) {
+    $record = (object) [
+        'name' => $data->name,
+        'keywords' => trim((string)$data->keywords),
+        'response' => trim((string)$data->response),
+        'isfallback' => empty($data->isfallback) ? 0 : 1,
+        'enabled' => empty($data->enabled) ? 0 : 1,
+        'sortorder' => (int)$data->sortorder,
+        'timemodified' => time(),
+    ];
+
+    if (!empty($data->id)) {
+        $record->id = $data->id;
+        $DB->update_record('local_chatbot_intents', $record);
+    } else {
+        $record->timecreated = time();
+        $record->id = $DB->insert_record('local_chatbot_intents', $record);
+    }
+
+    if ($record->isfallback) {
+        $DB->set_field_select('local_chatbot_intents', 'isfallback', 0, 'id <> ?', [$record->id]);
+        $DB->set_field('local_chatbot_intents', 'isfallback', 1, ['id' => $record->id]);
+    }
+
+    local_chatbot_reset_runtime_cache();
+
+    redirect($baseurl, get_string('intent_saved', 'local_chatbot'), null, \core\output\notification::NOTIFY_SUCCESS);
+}
+
+$PAGE->set_title(get_string('manage_intents', 'local_chatbot'));
+$PAGE->set_heading(get_string('manage_intents', 'local_chatbot'));
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
 
-echo $OUTPUT->notification(get_string('admin_placeholder', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
-echo $OUTPUT->notification(get_string('admin_placeholder_help', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+echo $OUTPUT->heading(get_string('manage_intents', 'local_chatbot'));
 
-echo html_writer::tag('p', html_writer::link(
-    new moodle_url('/admin/settings.php', ['section' => 'local_chatbot']),
-    get_string('pluginname', 'local_chatbot')
-));
+echo $OUTPUT->notification(get_string('intents_intro', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+
+if ($action === 'edit') {
+    echo $OUTPUT->heading(get_string('intent_edit_heading', 'local_chatbot'), 3);
+} else {
+    echo $OUTPUT->heading(get_string('intent_add_heading', 'local_chatbot'), 3);
+}
+
+$mform->display();
+
+echo $OUTPUT->heading(get_string('intent_table_heading', 'local_chatbot'), 3);
+
+$table = new flexible_table('local-chatbot-intents');
+$table->define_columns(['name', 'keywords', 'response', 'status', 'sortorder', 'actions']);
+$table->define_headers([
+    get_string('intent_name', 'local_chatbot'),
+    get_string('intent_keywords', 'local_chatbot'),
+    get_string('intent_response', 'local_chatbot'),
+    get_string('intent_status', 'local_chatbot'),
+    get_string('intent_sortorder', 'local_chatbot'),
+    get_string('actions'),
+]);
+$table->sortable(true, 'sortorder', SORT_ASC);
+$table->set_attribute('class', 'generaltable generalbox local-chatbot-intents-table');
+$table->setup();
+
+$records = $DB->get_records('local_chatbot_intents', null, 'sortorder ASC, name ASC');
+foreach ($records as $record) {
+    $keywords = implode(', ', local_chatbot_parse_keywords($record->keywords));
+    if ($keywords === '') {
+        $keywords = html_writer::span(get_string('intent_no_keywords', 'local_chatbot'), 'text-muted');
+    }
+
+    $statusparts = [];
+    $statusparts[] = $record->enabled ? get_string('enabled', 'core') : get_string('disabled', 'core');
+    if ($record->isfallback) {
+        $statusparts[] = get_string('intent_status_fallback', 'local_chatbot');
+    }
+    $status = implode(' · ', $statusparts);
+
+    $actions = [];
+    $actions[] = html_writer::link(new moodle_url($baseurl, ['action' => 'edit', 'id' => $record->id]), get_string('edit'));
+    $actions[] = html_writer::link(
+        new moodle_url($baseurl, ['action' => 'delete', 'id' => $record->id, 'sesskey' => sesskey()]),
+        get_string('delete'),
+        ['data-confirm' => get_string('intent_delete_confirm', 'local_chatbot', $record->name)]
+    );
+
+    $table->add_data([
+        format_string($record->name),
+        format_string($keywords),
+        format_text($record->response, FORMAT_PLAIN),
+        $status,
+        (int)$record->sortorder,
+        implode(' | ', $actions),
+    ]);
+}
+
+$table->finish_output();
 
 echo $OUTPUT->footer();

--- a/local/chatbot/admin/test.php
+++ b/local/chatbot/admin/test.php
@@ -15,30 +15,116 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Placeholder testing surface for the chatbot.
+ * Manual testing console for chatbot responses.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 
-admin_externalpage_setup('local_chatbot_test');
+use local_chatbot\form\test_form;
 
-$heading = get_string('test_chatbot', 'local_chatbot');
-$PAGE->set_title($heading);
-$PAGE->set_heading($heading);
+defined('MOODLE_INTERNAL') || die();
+
+admin_externalpage_setup('local_chatbot_test');
+require_capability('local/chatbot:manage', context_system::instance());
+
+$form = new test_form($PAGE->url);
+$result = null;
+$history = [];
+
+if ($form->is_cancelled()) {
+    redirect($PAGE->url);
+} else if ($data = $form->get_data()) {
+    $message = trim((string)$data->message);
+    $sessionid = trim((string)$data->sessionid) ?: null;
+
+    $result = local_chatbot_process_message($message, $sessionid);
+    $sessionid = $result['sessionid'];
+    $history = local_chatbot_get_conversation_history($sessionid, 20);
+}
+
+$PAGE->set_title(get_string('test_chatbot', 'local_chatbot'));
+$PAGE->set_heading(get_string('test_chatbot', 'local_chatbot'));
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
 
-echo $OUTPUT->notification(get_string('admin_placeholder', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
-echo $OUTPUT->notification(get_string('admin_placeholder_help', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+echo $OUTPUT->heading(get_string('test_chatbot', 'local_chatbot'));
 
-$welcome = get_config('local_chatbot', 'welcome_message')
-    ?: get_string('chatbot_welcome_template', 'local_chatbot');
-echo html_writer::tag('p', $welcome);
+echo $OUTPUT->notification(get_string('test_intro', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+
+$form->display();
+
+if ($result) {
+    $card = html_writer::start_div('card my-4');
+    $card .= html_writer::start_div('card-body');
+    $card .= html_writer::tag('h3', get_string('test_result_heading', 'local_chatbot'), ['class' => 'card-title']);
+    $card .= html_writer::tag('p', get_string('test_result_response', 'local_chatbot', $result['response']));
+    $card .= html_writer::tag('p', get_string('test_result_intent', 'local_chatbot', $result['intent']));
+    $card .= html_writer::tag('p', get_string('test_result_session', 'local_chatbot', $result['sessionid']));
+    $card .= html_writer::tag('p', get_string('test_result_logid', 'local_chatbot', $result['logid']));
+    $card .= html_writer::tag('p', get_string('test_result_time', 'local_chatbot', $result['response_time'] . ' ms'));
+    $card .= html_writer::end_div();
+    $card .= html_writer::end_div();
+    echo $card;
+
+    $suggestions = local_chatbot_get_suggestions_payload();
+    if ($suggestions) {
+        echo html_writer::tag('h4', get_string('test_suggestions_heading', 'local_chatbot'));
+        $list = [];
+        foreach ($suggestions as $suggestion) {
+            $list[] = html_writer::tag('li', format_string(($suggestion['icon'] ?? '') . ' ' . $suggestion['text']));
+        }
+        echo html_writer::tag('ul', implode('', $list), ['class' => 'list-inline']);
+    }
+
+    $quickactions = local_chatbot_get_quick_actions(true);
+    if ($quickactions) {
+        echo html_writer::tag('h4', get_string('test_quickactions_heading', 'local_chatbot'));
+        $rows = [];
+        foreach ($quickactions as $action) {
+            $rows[] = html_writer::tag('tr',
+                html_writer::tag('td', format_string($action['label'])) .
+                html_writer::tag('td', format_string($action['type'])) .
+                html_writer::tag('td', format_string($action['description']))
+            );
+        }
+        echo html_writer::tag('table',
+            html_writer::tag('thead', html_writer::tag('tr',
+                html_writer::tag('th', get_string('quickaction_name', 'local_chatbot')) .
+                html_writer::tag('th', get_string('quickaction_type', 'local_chatbot')) .
+                html_writer::tag('th', get_string('quickaction_description', 'local_chatbot'))
+            )) .
+            html_writer::tag('tbody', implode('', $rows)),
+            ['class' => 'generaltable']
+        );
+    }
+}
+
+if ($history) {
+    echo html_writer::tag('h4', get_string('test_history_heading', 'local_chatbot'));
+    $rows = [];
+    foreach ($history as $entry) {
+        $rows[] = html_writer::tag('tr',
+            html_writer::tag('td', userdate($entry->timecreated)) .
+            html_writer::tag('td', format_text($entry->message, FORMAT_PLAIN)) .
+            html_writer::tag('td', format_text($entry->response, FORMAT_PLAIN)) .
+            html_writer::tag('td', format_string($entry->intent)) .
+            html_writer::tag('td', format_string($entry->feedback ?? ''))
+        );
+    }
+    echo html_writer::tag('table',
+        html_writer::tag('thead', html_writer::tag('tr',
+            html_writer::tag('th', get_string('time')) .
+            html_writer::tag('th', get_string('message', 'local_chatbot')) .
+            html_writer::tag('th', get_string('response', 'local_chatbot')) .
+            html_writer::tag('th', get_string('intent', 'local_chatbot')) .
+            html_writer::tag('th', get_string('feedback', 'local_chatbot'))
+        )) .
+        html_writer::tag('tbody', implode('', $rows)),
+        ['class' => 'generaltable']
+    );
+}
 
 echo $OUTPUT->footer();

--- a/local/chatbot/admin/training.php
+++ b/local/chatbot/admin/training.php
@@ -15,26 +15,150 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Placeholder administration page for chatbot training utilities.
+ * Training console for testing intents and responses.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 
-admin_externalpage_setup('local_chatbot_training');
+use local_chatbot\form\training_form;
 
-$heading = get_string('training', 'local_chatbot');
-$PAGE->set_title($heading);
-$PAGE->set_heading($heading);
+defined('MOODLE_INTERNAL') || die();
+
+admin_externalpage_setup('local_chatbot_training');
+require_capability('local/chatbot:manage', context_system::instance());
+
+$form = new training_form($PAGE->url);
+$result = null;
+$history = [];
+$matchedkeywords = [];
+
+if ($form->is_cancelled()) {
+    redirect($PAGE->url);
+} else if ($data = $form->get_data()) {
+    $message = trim((string)$data->message);
+    $sessionid = trim((string)$data->sessionid);
+
+    if (!empty($data->logmessage)) {
+        $response = local_chatbot_process_message($message, $sessionid ?: null);
+        $result = [
+            'intent' => $response['intent'],
+            'response' => $response['response'],
+            'logged' => true,
+            'sessionid' => $response['sessionid'],
+            'logid' => $response['logid'],
+            'timestamp' => $response['timestamp'],
+        ];
+        $sessionid = $response['sessionid'];
+    } else {
+        $preview = local_chatbot_preview_message($message);
+        $result = [
+            'intent' => $preview['intent'],
+            'response' => $preview['response'],
+            'logged' => false,
+            'sessionid' => $sessionid,
+            'timestamp' => time(),
+        ];
+        if (!empty($preview['intentrecord']->keywords)) {
+            $matchedkeywords = local_chatbot_parse_keywords($preview['intentrecord']->keywords);
+        }
+        if (!empty($preview['matchedkeyword'])) {
+            $matchedkeywords[] = $preview['matchedkeyword'];
+            $matchedkeywords = array_unique($matchedkeywords);
+        }
+    }
+
+    if ($sessionid) {
+        $history = local_chatbot_get_conversation_history($sessionid, 20);
+    }
+}
+
+$PAGE->set_title(get_string('training', 'local_chatbot'));
+$PAGE->set_heading(get_string('training', 'local_chatbot'));
 
 echo $OUTPUT->header();
-echo $OUTPUT->heading($heading);
 
-echo $OUTPUT->notification(get_string('admin_placeholder', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
-echo $OUTPUT->notification(get_string('admin_placeholder_help', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+echo $OUTPUT->heading(get_string('training', 'local_chatbot'));
+
+echo $OUTPUT->notification(get_string('training_intro', 'local_chatbot'), \core\output\notification::NOTIFY_INFO);
+
+$form->display();
+
+if ($result) {
+    $status = $result['logged'] ? get_string('training_logged', 'local_chatbot') : get_string('training_preview', 'local_chatbot');
+    $details = html_writer::start_div('local-chatbot-training-result alert alert-info');
+    $details .= html_writer::tag('h3', get_string('training_result_heading', 'local_chatbot'));
+    $details .= html_writer::tag('p', html_writer::span(get_string('training_result_status', 'local_chatbot', $status)));
+    $details .= html_writer::tag('p', html_writer::span(get_string('training_result_intent', 'local_chatbot', $result['intent'])));
+    $details .= html_writer::tag('p', html_writer::span(get_string('training_result_response', 'local_chatbot', $result['response'])));
+    if (!empty($result['sessionid'])) {
+        $details .= html_writer::tag('p', html_writer::span(get_string('training_result_session', 'local_chatbot', $result['sessionid'])));
+    }
+    if (!empty($matchedkeywords)) {
+        $details .= html_writer::tag('p', get_string('training_result_keywords', 'local_chatbot', implode(', ', $matchedkeywords)));
+    }
+    $details .= html_writer::end_div();
+    echo $details;
+
+    echo $OUTPUT->heading(get_string('training_context_heading', 'local_chatbot'), 3);
+
+    $suggestions = local_chatbot_get_suggestions_payload();
+    if ($suggestions) {
+        $items = [];
+        foreach ($suggestions as $suggestion) {
+            $label = trim(($suggestion['icon'] ?? '') . ' ' . $suggestion['text']);
+            $items[] = html_writer::tag('li', format_string($label));
+        }
+        echo html_writer::tag('h4', get_string('training_context_suggestions', 'local_chatbot'));
+        echo html_writer::tag('ul', implode('', $items), ['class' => 'list-unstyled']);
+    }
+
+    $quickactions = local_chatbot_get_quick_actions(true);
+    if ($quickactions) {
+        $rows = [];
+        foreach ($quickactions as $action) {
+            $rows[] = html_writer::tag('tr',
+                html_writer::tag('td', format_string($action['label'])) .
+                html_writer::tag('td', format_string($action['type'])) .
+                html_writer::tag('td', format_string($action['description']))
+            );
+        }
+        echo html_writer::tag('h4', get_string('training_context_actions', 'local_chatbot'));
+        echo html_writer::tag('table',
+            html_writer::tag('thead', html_writer::tag('tr',
+                html_writer::tag('th', get_string('quickaction_name', 'local_chatbot')) .
+                html_writer::tag('th', get_string('quickaction_type', 'local_chatbot')) .
+                html_writer::tag('th', get_string('quickaction_description', 'local_chatbot'))
+            )) .
+            html_writer::tag('tbody', implode('', $rows)),
+            ['class' => 'generaltable']
+        );
+    }
+}
+
+if (!empty($history)) {
+    echo $OUTPUT->heading(get_string('training_history_heading', 'local_chatbot'), 3);
+    $rows = [];
+    foreach ($history as $entry) {
+        $rows[] = html_writer::tag('tr',
+            html_writer::tag('td', userdate($entry->timecreated)) .
+            html_writer::tag('td', format_text($entry->message, FORMAT_PLAIN)) .
+            html_writer::tag('td', format_text($entry->response, FORMAT_PLAIN)) .
+            html_writer::tag('td', format_string($entry->intent))
+        );
+    }
+    echo html_writer::tag('table',
+        html_writer::tag('thead', html_writer::tag('tr',
+            html_writer::tag('th', get_string('time')) .
+            html_writer::tag('th', get_string('message', 'local_chatbot')) .
+            html_writer::tag('th', get_string('response', 'local_chatbot')) .
+            html_writer::tag('th', get_string('intent', 'local_chatbot'))
+        )) .
+        html_writer::tag('tbody', implode('', $rows)),
+        ['class' => 'generaltable local-chatbot-training-history']
+    );
+}
 
 echo $OUTPUT->footer();

--- a/local/chatbot/amd/src/chatbot.js
+++ b/local/chatbot/amd/src/chatbot.js
@@ -68,6 +68,7 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
             this.maxlength = parseInt(config.maxlength, 10) || 500;
             this.initialised = false;
             this.typingTimer = null;
+            this.quickActions = {};
         }
 
         /**
@@ -139,23 +140,21 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
 
             this.$widget.on('click', '.suggestion-chip', function() {
                 const text = $(this).data('text');
-                const action = $(this).data('action');
-                if (action) {
-                    self.executeAction(action);
+                const mode = $(this).data('mode');
+                const target = $(this).data('target');
+
+                if (mode === 'action' && target) {
+                    self.handleQuickAction(target);
                 } else {
-                    self.$input.val(text);
+                    const message = target || text;
+                    self.$input.val(message);
                     self.sendMessage();
                 }
             });
 
             this.$widget.on('click', '.quick-action-btn', function() {
-                const action = $(this).data('action');
-                const url = $(this).data('url');
-                if (action === 'navigate' && url) {
-                    window.location.href = url;
-                    return;
-                }
-                self.executeAction(action);
+                const key = $(this).data('key');
+                self.handleQuickAction(key, $(this));
             });
 
             this.$widget.on('click', '.feedback-btn', function() {
@@ -306,7 +305,8 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
                 );
                 chip.text((suggestion.icon || '') + ' ' + suggestion.text);
                 chip.attr('data-text', suggestion.text);
-                chip.attr('data-action', suggestion.action || '');
+                chip.attr('data-mode', suggestion.mode || 'message');
+                chip.attr('data-target', suggestion.target || '');
                 container.append(chip);
             });
 
@@ -321,17 +321,21 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
         renderQuickActions(actions) {
             const container = this.$quickActions.find('.quick-actions-container');
             container.empty();
+            this.quickActions = {};
 
             if (!actions.length) {
                 this.$quickActions.hide();
                 return;
             }
 
+            const self = this;
             actions.forEach(function(action) {
+                self.quickActions[action.actionkey] = action;
                 const button = createElement(
                     '<button type="button" class="quick-action-btn"></button>'
                 );
-                button.attr('data-action', action.action);
+                button.attr('data-key', action.actionkey);
+                button.attr('data-type', action.type || 'navigate');
                 button.attr('data-url', action.url || '');
                 button.attr('title', action.description || '');
                 button.html('<span class="quick-action-icon">' + (action.icon || '') + '</span>' +
@@ -340,6 +344,34 @@ define(['jquery', 'core/ajax', 'core/notification'], function($, Ajax, Notificat
             });
 
             this.$quickActions.show();
+        }
+
+        /**
+         * Execute quick action locally or via AJAX.
+         *
+         * @param {string} key
+         * @param {JQuery} [$button]
+         */
+        handleQuickAction(key, $button) {
+            if (!key) {
+                return;
+            }
+
+            const action = this.quickActions[key];
+            if (action) {
+                if (action.type === 'navigate' && action.url) {
+                    window.location.href = action.url;
+                    return;
+                }
+
+                if (action.type === 'inject' && action.message) {
+                    this.$input.val(action.message);
+                    this.sendMessage();
+                    return;
+                }
+            }
+
+            this.executeAction(key);
         }
 
         /**

--- a/local/chatbot/classes/form/dialogue_filter_form.php
+++ b/local/chatbot/classes/form/dialogue_filter_form.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_chatbot\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Filter form for the dialogues console.
+ *
+ * @package     local_chatbot
+ */
+class dialogue_filter_form extends \moodleform {
+    /**
+     * Define the form.
+     */
+    public function definition() {
+        $mform = $this->_form;
+        $customdata = $this->_customdata ?? [];
+        $intentoptions = $customdata['intents'] ?? [];
+
+        $mform->addElement('text', 'sessionid', get_string('dialogue_filter_session', 'local_chatbot'));
+        $mform->setType('sessionid', PARAM_ALPHANUMEXT);
+
+        $mform->addElement('text', 'userid', get_string('dialogue_filter_userid', 'local_chatbot'));
+        $mform->setType('userid', PARAM_INT);
+
+        $mform->addElement('select', 'intent', get_string('dialogue_filter_intent', 'local_chatbot'), $intentoptions);
+        $mform->setDefault('intent', '');
+
+        $mform->addElement('date_selector', 'from', get_string('dialogue_filter_from', 'local_chatbot'), ['optional' => true]);
+        $mform->addElement('date_selector', 'to', get_string('dialogue_filter_to', 'local_chatbot'), ['optional' => true]);
+
+        $mform->addElement('advcheckbox', 'hasfeedback', get_string('dialogue_filter_feedback', 'local_chatbot'));
+
+        $mform->disable_form_change_checker();
+
+        $buttonarray = [];
+        $buttonarray[] = $mform->createElement('submit', 'submitbutton', get_string('dialogue_filter_apply', 'local_chatbot'));
+        $buttonarray[] = $mform->createElement('submit', 'resetbutton', get_string('dialogue_filter_reset', 'local_chatbot'));
+        $mform->addGroup($buttonarray, 'buttonar', '', [' '], false);
+    }
+}

--- a/local/chatbot/classes/form/intent_form.php
+++ b/local/chatbot/classes/form/intent_form.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_chatbot\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form used to create or edit chatbot intents.
+ *
+ * @package     local_chatbot
+ * @copyright   2024 Moodle Community
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class intent_form extends \moodleform {
+    /**
+     * Define the form.
+     */
+    public function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_INT);
+
+        $mform->addElement('text', 'name', get_string('intent_name', 'local_chatbot'));
+        $mform->setType('name', PARAM_TEXT);
+        $mform->addRule('name', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('textarea', 'keywords', get_string('intent_keywords', 'local_chatbot'), 'rows="4" cols="60"');
+        $mform->setType('keywords', PARAM_RAW);
+        $mform->addHelpButton('keywords', 'intent_keywords', 'local_chatbot');
+
+        $mform->addElement('textarea', 'response', get_string('intent_response', 'local_chatbot'), 'rows="5" cols="60"');
+        $mform->setType('response', PARAM_RAW);
+        $mform->addRule('response', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('advcheckbox', 'isfallback', get_string('intent_fallback', 'local_chatbot'));
+        $mform->addHelpButton('isfallback', 'intent_fallback', 'local_chatbot');
+
+        $mform->addElement('advcheckbox', 'enabled', get_string('intent_enabled', 'local_chatbot'));
+        $mform->setDefault('enabled', 1);
+
+        $mform->addElement('text', 'sortorder', get_string('intent_sortorder', 'local_chatbot'));
+        $mform->setType('sortorder', PARAM_INT);
+        $mform->setDefault('sortorder', 10);
+
+        $this->add_action_buttons();
+    }
+
+    /**
+     * Custom validation rules.
+     *
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
+    public function validation($data, $files): array {
+        $errors = parent::validation($data, $files);
+
+        if (empty($data['isfallback'])) {
+            $keywords = local_chatbot_parse_keywords($data['keywords'] ?? '');
+            if (empty($keywords)) {
+                $errors['keywords'] = get_string('intent_keywords_required', 'local_chatbot');
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/local/chatbot/classes/form/quickaction_form.php
+++ b/local/chatbot/classes/form/quickaction_form.php
@@ -1,0 +1,115 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_chatbot\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form to create or edit chatbot quick actions.
+ *
+ * @package     local_chatbot
+ */
+class quickaction_form extends \moodleform {
+    /**
+     * Define form structure.
+     */
+    public function definition() {
+        $mform = $this->_form;
+        $customdata = $this->_customdata ?? [];
+        $currentid = $customdata['id'] ?? 0;
+
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_INT);
+        if ($currentid) {
+            $mform->setDefault('id', $currentid);
+        }
+
+        $mform->addElement('text', 'actionkey', get_string('quickaction_actionkey', 'local_chatbot'));
+        $mform->setType('actionkey', PARAM_ALPHANUMEXT);
+        $mform->addRule('actionkey', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('text', 'name', get_string('quickaction_name', 'local_chatbot'));
+        $mform->setType('name', PARAM_TEXT);
+        $mform->addRule('name', get_string('required'), 'required', null, 'client');
+
+        $options = [
+            'navigate' => get_string('quickaction_type_navigate', 'local_chatbot'),
+            'inject' => get_string('quickaction_type_inject', 'local_chatbot'),
+            'server' => get_string('quickaction_type_server', 'local_chatbot'),
+        ];
+        $mform->addElement('select', 'type', get_string('quickaction_type', 'local_chatbot'), $options);
+        $mform->setDefault('type', 'navigate');
+        $mform->addHelpButton('type', 'quickaction_type', 'local_chatbot');
+
+        $mform->addElement('textarea', 'payload', get_string('quickaction_payload', 'local_chatbot'), 'rows="4" cols="60"');
+        $mform->setType('payload', PARAM_RAW);
+        $mform->addHelpButton('payload', 'quickaction_payload', 'local_chatbot');
+
+        $mform->addElement('text', 'description', get_string('quickaction_description', 'local_chatbot'));
+        $mform->setType('description', PARAM_TEXT);
+
+        $mform->addElement('text', 'icon', get_string('quickaction_icon', 'local_chatbot'), 'maxlength="10"');
+        $mform->setType('icon', PARAM_TEXT);
+        $mform->addHelpButton('icon', 'quickaction_icon', 'local_chatbot');
+
+        $mform->addElement('advcheckbox', 'enabled', get_string('quickaction_enabled', 'local_chatbot'));
+        $mform->setDefault('enabled', 1);
+
+        $mform->addElement('text', 'sortorder', get_string('quickaction_sortorder', 'local_chatbot'));
+        $mform->setType('sortorder', PARAM_INT);
+        $mform->setDefault('sortorder', 10);
+
+        $this->add_action_buttons();
+    }
+
+    /**
+     * Validate quick action data.
+     *
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
+    public function validation($data, $files): array {
+        $errors = parent::validation($data, $files);
+
+        global $DB;
+
+        $payload = trim((string)($data['payload'] ?? ''));
+        $type = $data['type'] ?? 'navigate';
+
+        if ($type === 'navigate' && $payload === '') {
+            $errors['payload'] = get_string('quickaction_payload_required', 'local_chatbot');
+        }
+
+        if ($type !== 'navigate' && $payload === '') {
+            $errors['payload'] = get_string('quickaction_payload_text_required', 'local_chatbot');
+        }
+
+        $id = (int)($data['id'] ?? 0);
+        $actionkey = trim((string)($data['actionkey'] ?? ''));
+        if ($actionkey !== '') {
+            $existing = $DB->get_record('local_chatbot_quickacts', ['actionkey' => $actionkey]);
+            if ($existing && (int)$existing->id !== $id) {
+                $errors['actionkey'] = get_string('quickaction_actionkey_unique', 'local_chatbot');
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/local/chatbot/classes/form/suggestion_form.php
+++ b/local/chatbot/classes/form/suggestion_form.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_chatbot\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form to manage suggestion chips.
+ *
+ * @package     local_chatbot
+ */
+class suggestion_form extends \moodleform {
+    /**
+     * Define form fields.
+     */
+    public function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('hidden', 'id');
+        $mform->setType('id', PARAM_INT);
+
+        $mform->addElement('text', 'text', get_string('suggestion_text', 'local_chatbot'));
+        $mform->setType('text', PARAM_TEXT);
+        $mform->addRule('text', get_string('required'), 'required', null, 'client');
+
+        $options = [
+            'message' => get_string('suggestion_mode_message', 'local_chatbot'),
+            'action' => get_string('suggestion_mode_action', 'local_chatbot'),
+        ];
+        $mform->addElement('select', 'mode', get_string('suggestion_mode', 'local_chatbot'), $options);
+        $mform->setDefault('mode', 'message');
+        $mform->addHelpButton('mode', 'suggestion_mode', 'local_chatbot');
+
+        $mform->addElement('text', 'target', get_string('suggestion_target', 'local_chatbot'));
+        $mform->setType('target', PARAM_TEXT);
+        $mform->addHelpButton('target', 'suggestion_target', 'local_chatbot');
+
+        $mform->addElement('text', 'icon', get_string('suggestion_icon', 'local_chatbot'), 'maxlength="10"');
+        $mform->setType('icon', PARAM_TEXT);
+
+        $mform->addElement('advcheckbox', 'enabled', get_string('suggestion_enabled', 'local_chatbot'));
+        $mform->setDefault('enabled', 1);
+
+        $mform->addElement('text', 'sortorder', get_string('suggestion_sortorder', 'local_chatbot'));
+        $mform->setType('sortorder', PARAM_INT);
+        $mform->setDefault('sortorder', 10);
+
+        $this->add_action_buttons();
+    }
+
+    /**
+     * Validate suggestion.
+     *
+     * @param array $data
+     * @param array $files
+     * @return array
+     */
+    public function validation($data, $files): array {
+        $errors = parent::validation($data, $files);
+
+        if (($data['mode'] ?? 'message') === 'action' && empty($data['target'])) {
+            $errors['target'] = get_string('suggestion_target_required', 'local_chatbot');
+        }
+
+        return $errors;
+    }
+}

--- a/local/chatbot/classes/form/test_form.php
+++ b/local/chatbot/classes/form/test_form.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_chatbot\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form used in the manual testing console.
+ *
+ * @package     local_chatbot
+ */
+class test_form extends \moodleform {
+    /**
+     * Define the form.
+     */
+    public function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('textarea', 'message', get_string('test_message', 'local_chatbot'), 'rows="4" cols="80"');
+        $mform->setType('message', PARAM_RAW);
+        $mform->addRule('message', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('text', 'sessionid', get_string('test_sessionid', 'local_chatbot'));
+        $mform->setType('sessionid', PARAM_ALPHANUMEXT);
+        $mform->addHelpButton('sessionid', 'test_sessionid', 'local_chatbot');
+
+        $this->add_action_buttons(false, get_string('test_send', 'local_chatbot'));
+    }
+}

--- a/local/chatbot/classes/form/training_form.php
+++ b/local/chatbot/classes/form/training_form.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_chatbot\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form used on the training page to run classification previews.
+ *
+ * @package     local_chatbot
+ */
+class training_form extends \moodleform {
+    /**
+     * Define form.
+     */
+    public function definition() {
+        $mform = $this->_form;
+
+        $mform->addElement('textarea', 'message', get_string('training_message', 'local_chatbot'), 'rows="4" cols="80"');
+        $mform->setType('message', PARAM_RAW);
+        $mform->addRule('message', get_string('required'), 'required', null, 'client');
+
+        $mform->addElement('advcheckbox', 'logmessage', get_string('training_logmessage', 'local_chatbot'));
+        $mform->addHelpButton('logmessage', 'training_logmessage', 'local_chatbot');
+
+        $mform->addElement('text', 'sessionid', get_string('training_sessionid', 'local_chatbot'));
+        $mform->setType('sessionid', PARAM_ALPHANUMEXT);
+        $mform->addHelpButton('sessionid', 'training_sessionid', 'local_chatbot');
+
+        $this->add_action_buttons(false, get_string('training_run', 'local_chatbot'));
+    }
+}

--- a/local/chatbot/db/install.xml
+++ b/local/chatbot/db/install.xml
@@ -26,5 +26,69 @@
         <INDEX NAME="timecreated" UNIQUE="false" FIELDS="timecreated"/>
       </INDEXES>
     </TABLE>
+    <TABLE NAME="local_chatbot_intents" COMMENT="Keyword driven responses for the chatbot">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="100" NOTNULL="true" COMMENT="Administrative label"/>
+        <FIELD NAME="keywords" TYPE="text" NOTNULL="false" COMMENT="New line separated keywords"/>
+        <FIELD NAME="response" TYPE="text" NOTNULL="true" COMMENT="Response sent when matched"/>
+        <FIELD NAME="isfallback" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" COMMENT="Whether this intent is fallback"/>
+        <FIELD NAME="enabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" COMMENT="Whether the intent is active"/>
+        <FIELD NAME="sortorder" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" COMMENT="Display order"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="enabled" UNIQUE="false" FIELDS="enabled"/>
+        <INDEX NAME="sortorder" UNIQUE="false" FIELDS="sortorder"/>
+        <INDEX NAME="fallback" UNIQUE="false" FIELDS="isfallback"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_chatbot_suggestions" COMMENT="Suggestion chips displayed inside the chatbot">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="text" TYPE="char" LENGTH="255" NOTNULL="true" COMMENT="Displayed suggestion text"/>
+        <FIELD NAME="mode" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="message" COMMENT="message or action"/>
+        <FIELD NAME="target" TYPE="char" LENGTH="100" NOTNULL="false" COMMENT="Action key or message value"/>
+        <FIELD NAME="icon" TYPE="char" LENGTH="20" NOTNULL="false" COMMENT="Emoji icon"/>
+        <FIELD NAME="enabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" COMMENT="Whether the suggestion is active"/>
+        <FIELD NAME="sortorder" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" COMMENT="Display order"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="enabled" UNIQUE="false" FIELDS="enabled"/>
+        <INDEX NAME="sortorder" UNIQUE="false" FIELDS="sortorder"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_chatbot_quickacts" COMMENT="Quick action shortcuts for the chatbot">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="100" NOTNULL="true" COMMENT="Display label"/>
+        <FIELD NAME="actionkey" TYPE="char" LENGTH="100" NOTNULL="true" COMMENT="Identifier used by the widget"/>
+        <FIELD NAME="type" TYPE="char" LENGTH="20" NOTNULL="true" DEFAULT="navigate" COMMENT="navigate|inject|server"/>
+        <FIELD NAME="payload" TYPE="text" NOTNULL="false" COMMENT="URL or payload"/>
+        <FIELD NAME="description" TYPE="char" LENGTH="255" NOTNULL="false" COMMENT="Tooltip description"/>
+        <FIELD NAME="icon" TYPE="char" LENGTH="20" NOTNULL="false" COMMENT="Emoji icon"/>
+        <FIELD NAME="enabled" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" COMMENT="Whether the action is active"/>
+        <FIELD NAME="sortorder" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" COMMENT="Display order"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="enabled" UNIQUE="false" FIELDS="enabled"/>
+        <INDEX NAME="sortorder" UNIQUE="false" FIELDS="sortorder"/>
+        <INDEX NAME="actionkey" UNIQUE="true" FIELDS="actionkey"/>
+      </INDEXES>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/local/chatbot/db/upgrade.php
+++ b/local/chatbot/db/upgrade.php
@@ -70,6 +70,197 @@ function xmldb_local_chatbot_upgrade(int $oldversion): bool {
         upgrade_plugin_savepoint(true, 2025012503, 'local', 'chatbot');
     }
 
+    if ($oldversion < 2025020100) {
+        $table = new xmldb_table('local_chatbot_intents');
+
+        if (!$dbman->table_exists($table)) {
+            $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+            $table->add_field('name', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('keywords', XMLDB_TYPE_TEXT, null, null, null, null, null);
+            $table->add_field('response', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+            $table->add_field('isfallback', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('enabled', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+            $table->add_field('sortorder', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+            $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+            $table->add_index('enabled', XMLDB_INDEX_NOTUNIQUE, ['enabled']);
+            $table->add_index('sortorder', XMLDB_INDEX_NOTUNIQUE, ['sortorder']);
+            $table->add_index('fallback', XMLDB_INDEX_NOTUNIQUE, ['isfallback']);
+
+            $dbman->create_table($table);
+        }
+
+        $table = new xmldb_table('local_chatbot_suggestions');
+        if (!$dbman->table_exists($table)) {
+            $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+            $table->add_field('text', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('mode', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'message');
+            $table->add_field('target', XMLDB_TYPE_CHAR, '100', null, null, null, null);
+            $table->add_field('icon', XMLDB_TYPE_CHAR, '20', null, null, null, null);
+            $table->add_field('enabled', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+            $table->add_field('sortorder', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+            $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+            $table->add_index('enabled', XMLDB_INDEX_NOTUNIQUE, ['enabled']);
+            $table->add_index('sortorder', XMLDB_INDEX_NOTUNIQUE, ['sortorder']);
+
+            $dbman->create_table($table);
+        }
+
+        $table = new xmldb_table('local_chatbot_quickacts');
+        if (!$dbman->table_exists($table)) {
+            $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+            $table->add_field('name', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('actionkey', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('type', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, 'navigate');
+            $table->add_field('payload', XMLDB_TYPE_TEXT, null, null, null, null, null);
+            $table->add_field('description', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+            $table->add_field('icon', XMLDB_TYPE_CHAR, '20', null, null, null, null);
+            $table->add_field('enabled', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+            $table->add_field('sortorder', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+            $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+            $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+            $table->add_index('enabled', XMLDB_INDEX_NOTUNIQUE, ['enabled']);
+            $table->add_index('sortorder', XMLDB_INDEX_NOTUNIQUE, ['sortorder']);
+            $table->add_index('actionkey', XMLDB_INDEX_UNIQUE, ['actionkey']);
+
+            $dbman->create_table($table);
+        }
+
+        $time = time();
+
+        if (!$DB->count_records('local_chatbot_intents')) {
+            $intents = [
+                [
+                    'name' => 'Greeting',
+                    'keywords' => "hola\nhello\nhi\nbuenos\nbuenas",
+                    'response' => get_string('chatbot_response_greeting', 'local_chatbot'),
+                    'isfallback' => 0,
+                    'sortorder' => 10,
+                ],
+                [
+                    'name' => 'Help',
+                    'keywords' => "ayuda\nhelp\nassist\nsoporte",
+                    'response' => get_string('chatbot_response_help', 'local_chatbot'),
+                    'isfallback' => 0,
+                    'sortorder' => 20,
+                ],
+                [
+                    'name' => 'Courses',
+                    'keywords' => "curso\ncourses\nclase\nsubject",
+                    'response' => get_string('chatbot_response_courses', 'local_chatbot'),
+                    'isfallback' => 0,
+                    'sortorder' => 30,
+                ],
+                [
+                    'name' => 'Grades',
+                    'keywords' => "nota\ncalificación\ncalificacion\ngrade",
+                    'response' => get_string('chatbot_response_grades', 'local_chatbot'),
+                    'isfallback' => 0,
+                    'sortorder' => 40,
+                ],
+                [
+                    'name' => 'Fallback',
+                    'keywords' => '',
+                    'response' => (string)(get_config('local_chatbot', 'default_nomatch')
+                        ?: get_string('default_nomatch', 'local_chatbot')),
+                    'isfallback' => 1,
+                    'sortorder' => 99,
+                ],
+            ];
+
+            foreach ($intents as $intent) {
+                $record = (object) $intent;
+                $record->enabled = 1;
+                $record->timecreated = $time;
+                $record->timemodified = $time;
+                $DB->insert_record('local_chatbot_intents', $record);
+            }
+        }
+
+        if (!$DB->count_records('local_chatbot_quickacts')) {
+            $quickactions = [
+                [
+                    'name' => get_string('chatbot_action_profile', 'local_chatbot'),
+                    'actionkey' => 'navigate_profile',
+                    'type' => 'navigate',
+                    'payload' => '/user/profile.php?id={userid}',
+                    'description' => get_string('chatbot_action_profile_desc', 'local_chatbot'),
+                    'icon' => '👤',
+                    'sortorder' => 10,
+                ],
+                [
+                    'name' => get_string('chatbot_action_calendar', 'local_chatbot'),
+                    'actionkey' => 'navigate_calendar',
+                    'type' => 'navigate',
+                    'payload' => '/calendar/view.php?view=month',
+                    'description' => get_string('chatbot_action_calendar_desc', 'local_chatbot'),
+                    'icon' => '🗓️',
+                    'sortorder' => 20,
+                ],
+                [
+                    'name' => get_string('chatbot_action_support', 'local_chatbot'),
+                    'actionkey' => 'server_support',
+                    'type' => 'server',
+                    'payload' => get_string('chatbot_response_support', 'local_chatbot'),
+                    'description' => get_string('chatbot_action_support_desc', 'local_chatbot'),
+                    'icon' => '🆘',
+                    'sortorder' => 30,
+                ],
+            ];
+
+            foreach ($quickactions as $action) {
+                $record = (object) $action;
+                $record->enabled = 1;
+                $record->timecreated = $time;
+                $record->timemodified = $time;
+                $DB->insert_record('local_chatbot_quickacts', $record);
+            }
+        }
+
+        if (!$DB->count_records('local_chatbot_suggestions')) {
+            $suggestions = [
+                [
+                    'text' => get_string('chatbot_suggestion_courses', 'local_chatbot'),
+                    'mode' => 'message',
+                    'target' => get_string('chatbot_suggestion_courses', 'local_chatbot'),
+                    'icon' => '📚',
+                    'sortorder' => 10,
+                ],
+                [
+                    'text' => get_string('chatbot_suggestion_grades', 'local_chatbot'),
+                    'mode' => 'message',
+                    'target' => get_string('chatbot_suggestion_grades', 'local_chatbot'),
+                    'icon' => '📊',
+                    'sortorder' => 20,
+                ],
+                [
+                    'text' => get_string('chatbot_suggestion_support', 'local_chatbot'),
+                    'mode' => 'action',
+                    'target' => 'server_support',
+                    'icon' => '🆘',
+                    'sortorder' => 30,
+                ],
+            ];
+
+            foreach ($suggestions as $suggestion) {
+                $record = (object) $suggestion;
+                $record->enabled = 1;
+                $record->timecreated = $time;
+                $record->timemodified = $time;
+                $DB->insert_record('local_chatbot_suggestions', $record);
+            }
+        }
+
+        upgrade_plugin_savepoint(true, 2025020100, 'local', 'chatbot');
+    }
+
     return true;
 }
 

--- a/local/chatbot/externallib.php
+++ b/local/chatbot/externallib.php
@@ -67,22 +67,25 @@ class local_chatbot_external extends external_api {
         $result = local_chatbot_process_message($params['message'], $params['sessionid'] ?: null);
 
         $suggestions = [];
-        foreach (local_chatbot_get_suggestions() as $suggestion) {
+        foreach (local_chatbot_get_suggestions_payload() as $suggestion) {
             $suggestions[] = [
                 'text' => $suggestion['text'],
-                'action' => $suggestion['action'],
-                'icon' => $suggestion['icon'] ?? '',
+                'mode' => $suggestion['mode'],
+                'target' => $suggestion['target'],
+                'icon' => $suggestion['icon'],
             ];
         }
 
         $actions = [];
         foreach (local_chatbot_get_quick_actions() as $action) {
             $actions[] = [
-                'action' => $action['action'],
+                'actionkey' => $action['actionkey'],
                 'label' => $action['label'],
                 'icon' => $action['icon'],
                 'description' => $action['description'],
-                'url' => $action['url']->out(false),
+                'type' => $action['type'],
+                'message' => $action['message'],
+                'url' => $action['url'] instanceof moodle_url ? $action['url']->out(false) : '',
             ];
         }
 
@@ -113,15 +116,18 @@ class local_chatbot_external extends external_api {
             'timestamp' => new external_value(PARAM_INT, 'Creation time'),
             'suggestions' => new external_multiple_structure(new external_single_structure([
                 'text' => new external_value(PARAM_TEXT, 'Suggestion text'),
-                'action' => new external_value(PARAM_TEXT, 'Action key'),
+                'mode' => new external_value(PARAM_TEXT, 'Suggestion mode (message|action)'),
+                'target' => new external_value(PARAM_TEXT, 'Target message or action key', VALUE_DEFAULT, ''),
                 'icon' => new external_value(PARAM_TEXT, 'Emoji icon', VALUE_DEFAULT, ''),
             ]), 'Contextual suggestions'),
             'actions' => new external_multiple_structure(new external_single_structure([
-                'action' => new external_value(PARAM_TEXT, 'Action identifier'),
+                'actionkey' => new external_value(PARAM_TEXT, 'Action identifier'),
                 'label' => new external_value(PARAM_TEXT, 'Action label'),
                 'icon' => new external_value(PARAM_TEXT, 'Icon to display'),
                 'description' => new external_value(PARAM_TEXT, 'Tooltip description'),
-                'url' => new external_value(PARAM_URL, 'Destination URL'),
+                'type' => new external_value(PARAM_TEXT, 'Action type'),
+                'message' => new external_value(PARAM_RAW, 'Optional payload message', VALUE_DEFAULT, ''),
+                'url' => new external_value(PARAM_TEXT, 'Destination URL', VALUE_DEFAULT, ''),
             ]), 'Quick actions'),
         ]);
     }
@@ -149,11 +155,12 @@ class local_chatbot_external extends external_api {
         require_capability('local/chatbot:use', $systemcontext);
 
         $suggestions = [];
-        foreach (local_chatbot_get_suggestions() as $suggestion) {
+        foreach (local_chatbot_get_suggestions_payload() as $suggestion) {
             $suggestions[] = [
                 'text' => $suggestion['text'],
-                'action' => $suggestion['action'],
-                'icon' => $suggestion['icon'] ?? '',
+                'mode' => $suggestion['mode'],
+                'target' => $suggestion['target'],
+                'icon' => $suggestion['icon'],
             ];
         }
 
@@ -166,7 +173,8 @@ class local_chatbot_external extends external_api {
     public static function get_suggestions_returns(): external_multiple_structure {
         return new external_multiple_structure(new external_single_structure([
             'text' => new external_value(PARAM_TEXT, 'Suggestion text'),
-            'action' => new external_value(PARAM_TEXT, 'Action key'),
+            'mode' => new external_value(PARAM_TEXT, 'Suggestion mode (message|action)'),
+            'target' => new external_value(PARAM_TEXT, 'Target message or action key', VALUE_DEFAULT, ''),
             'icon' => new external_value(PARAM_TEXT, 'Emoji icon', VALUE_DEFAULT, ''),
         ]));
     }
@@ -196,11 +204,13 @@ class local_chatbot_external extends external_api {
         $actions = [];
         foreach (local_chatbot_get_quick_actions() as $action) {
             $actions[] = [
-                'action' => $action['action'],
+                'actionkey' => $action['actionkey'],
                 'label' => $action['label'],
                 'icon' => $action['icon'],
                 'description' => $action['description'],
-                'url' => $action['url']->out(false),
+                'type' => $action['type'],
+                'message' => $action['message'],
+                'url' => $action['url'] instanceof moodle_url ? $action['url']->out(false) : '',
             ];
         }
 
@@ -212,11 +222,13 @@ class local_chatbot_external extends external_api {
      */
     public static function get_quick_actions_returns(): external_multiple_structure {
         return new external_multiple_structure(new external_single_structure([
-            'action' => new external_value(PARAM_TEXT, 'Action identifier'),
+            'actionkey' => new external_value(PARAM_TEXT, 'Action identifier'),
             'label' => new external_value(PARAM_TEXT, 'Display label'),
             'icon' => new external_value(PARAM_TEXT, 'Icon'),
             'description' => new external_value(PARAM_TEXT, 'Tooltip description'),
-            'url' => new external_value(PARAM_URL, 'Destination URL'),
+            'type' => new external_value(PARAM_TEXT, 'Action type'),
+            'message' => new external_value(PARAM_RAW, 'Optional message payload', VALUE_DEFAULT, ''),
+            'url' => new external_value(PARAM_TEXT, 'Destination URL', VALUE_DEFAULT, ''),
         ]));
     }
 
@@ -365,7 +377,7 @@ class local_chatbot_external extends external_api {
      */
     public static function execute_action_parameters(): external_function_parameters {
         return new external_function_parameters([
-            'action' => new external_value(PARAM_TEXT, 'Action identifier'),
+            'action' => new external_value(PARAM_TEXT, 'Action key identifier'),
             'params' => new external_value(PARAM_TEXT, 'JSON encoded parameters', VALUE_DEFAULT, '{}'),
         ]);
     }
@@ -378,6 +390,8 @@ class local_chatbot_external extends external_api {
      * @return array
      */
     public static function execute_action(string $action, string $params = '{}'): array {
+        global $DB;
+
         $params = self::validate_parameters(self::execute_action_parameters(), [
             'action' => $action,
             'params' => $params,
@@ -387,9 +401,38 @@ class local_chatbot_external extends external_api {
         self::validate_context($systemcontext);
         require_capability('local/chatbot:use', $systemcontext);
 
-        $decodedparams = json_decode($params['params'], true) ?: [];
+        $record = $DB->get_record('local_chatbot_quickacts', [
+            'actionkey' => $params['action'],
+            'enabled' => 1,
+        ]);
 
-        $message = get_string('chatbot_action_generic', 'local_chatbot', $params['action']);
+        if (!$record) {
+            return [
+                'success' => false,
+                'message' => get_string('chatbot_action_unknown', 'local_chatbot'),
+            ];
+        }
+
+        if ($record->type === 'server') {
+            $message = trim((string)$record->payload);
+            if ($message === '') {
+                $message = get_string('chatbot_action_generic', 'local_chatbot', $record->name);
+            }
+
+            return [
+                'success' => true,
+                'message' => format_text($message, FORMAT_PLAIN),
+            ];
+        }
+
+        if ($record->type === 'inject') {
+            return [
+                'success' => true,
+                'message' => format_text((string)$record->payload, FORMAT_PLAIN),
+            ];
+        }
+
+        $message = get_string('chatbot_action_generic', 'local_chatbot', $record->name);
 
         return [
             'success' => true,

--- a/local/chatbot/lang/en/local_chatbot.php
+++ b/local/chatbot/lang/en/local_chatbot.php
@@ -18,8 +18,6 @@
  * English language strings for the local_chatbot plugin.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 $string['pluginname'] = 'Chatbot assistant';
@@ -55,13 +53,16 @@ $string['chatbot_action_profile'] = 'My profile';
 $string['chatbot_action_profile_desc'] = 'Open your profile page';
 $string['chatbot_action_calendar'] = 'Calendar';
 $string['chatbot_action_calendar_desc'] = 'Open the calendar view';
+$string['chatbot_action_support'] = 'Support centre';
+$string['chatbot_action_support_desc'] = 'Display the institutional support contact options';
 $string['chatbot_action_generic'] = 'Action executed: {$a}';
 
 // Responses.
 $string['chatbot_response_greeting'] = 'Hello! 👋 How can I help you today?';
-$string['chatbot_response_help'] = 'I can help you locate courses, grades and useful links. Try asking "Where do I see my grades?"';
-$string['chatbot_response_courses'] = 'Open the "My courses" menu at the top of the site to see your enrolled courses.';
+$string['chatbot_response_help'] = 'I can help you locate courses, grades and useful links. Try asking “Where do I see my grades?”';
+$string['chatbot_response_courses'] = 'Open the “My courses” menu at the top of the site to see your enrolled courses.';
 $string['chatbot_response_grades'] = 'Visit the grades page from the user menu or open the Grades option inside each course.';
+$string['chatbot_response_support'] = 'You can reach our support team via the help centre or by emailing the academic support mailbox.';
 
 // Export.
 $string['chatbot_export_heading'] = 'Conversation history';
@@ -97,17 +98,155 @@ $string['setting_maxlength_desc'] = 'Limit the amount of characters users can se
 $string['setting_allow_export'] = 'Allow conversation export';
 $string['setting_allow_export_desc'] = 'Show the export button when the user has the export capability.';
 
-// Admin placeholder screens.
-$string['admin_placeholder'] = 'The management console is being prepared. The widget and web services are fully functional.';
-$string['admin_placeholder_help'] = 'Continue using the Site administration settings page to configure the chatbot in the meantime.';
+// Intents management.
 $string['manage_intents'] = 'Manage intents';
+$string['intents_intro'] = 'Maintain the intents that power the rule-based chatbot classifier. Keywords are matched in order and a single intent can act as the global fallback.';
+$string['intent_name'] = 'Intent name';
+$string['intent_keywords'] = 'Keywords';
+$string['intent_keywords_help'] = 'Provide one keyword per line. Keywords are matched case-insensitively against the user message.';
+$string['intent_response'] = 'Response template';
+$string['intent_fallback'] = 'Use as fallback intent';
+$string['intent_fallback_help'] = 'If enabled this response will be returned whenever no other intent matches.';
+$string['intent_enabled'] = 'Enabled';
+$string['intent_sortorder'] = 'Sort order';
+$string['intent_status'] = 'Status';
+$string['intent_status_fallback'] = 'Fallback';
+$string['intent_no_keywords'] = 'No keywords';
+$string['intent_keywords_required'] = 'Provide at least one keyword or mark the intent as fallback.';
+$string['intent_unknown'] = 'Unclassified';
+$string['intent_edit_heading'] = 'Edit intent';
+$string['intent_add_heading'] = 'Add intent';
+$string['intent_table_heading'] = 'Configured intents';
+$string['intent_saved'] = 'Intent saved successfully.';
+$string['intent_deleted'] = 'Intent deleted.';
+$string['intent_delete_confirm'] = 'Do you really want to delete the intent "{$a}"?';
+
+// Entities (quick actions & suggestions).
 $string['manage_entities'] = 'Manage entities';
+$string['entities_intro'] = 'Quick actions and suggestions define the shortcuts and hints that the assistant shows to end users.';
+$string['entities_quickactions_tab'] = 'Quick actions';
+$string['entities_suggestions_tab'] = 'Suggestions';
+$string['quickaction_actionkey'] = 'Action key';
+$string['quickaction_name'] = 'Label';
+$string['quickaction_type'] = 'Action type';
+$string['quickaction_type_help'] = 'Choose how the quick action behaves: navigating to a page, injecting a message in the composer or returning a server-side response.';
+$string['quickaction_type_navigate'] = 'Navigate to a page';
+$string['quickaction_type_inject'] = 'Prefill message';
+$string['quickaction_type_server'] = 'Server reply';
+$string['quickaction_payload'] = 'Payload';
+$string['quickaction_payload_help'] = 'For navigation provide a relative path such as /user/profile.php?id={userid}. Inject/server actions use plain text as payload.';
+$string['quickaction_description'] = 'Description';
+$string['quickaction_icon'] = 'Icon / emoji';
+$string['quickaction_icon_help'] = 'Optional emoji or short text used as the icon in the widget.';
+$string['quickaction_enabled'] = 'Enabled';
+$string['quickaction_sortorder'] = 'Sort order';
+$string['quickaction_status'] = 'Status';
+$string['quickaction_payload_required'] = 'Provide a URL or path for navigation actions.';
+$string['quickaction_payload_text_required'] = 'Provide the message payload for this quick action.';
+$string['quickaction_actionkey_unique'] = 'The action key must be unique.';
+$string['quickaction_edit_heading'] = 'Edit quick action';
+$string['quickaction_add_heading'] = 'Add quick action';
+$string['quickaction_table_heading'] = 'Configured quick actions';
+$string['quickaction_saved'] = 'Quick action saved.';
+$string['quickaction_deleted'] = 'Quick action deleted.';
+$string['quickaction_delete_confirm'] = 'Delete the quick action "{$a}"?';
+
+$string['suggestion_text'] = 'Suggestion text';
+$string['suggestion_mode'] = 'Suggestion behaviour';
+$string['suggestion_mode_help'] = 'Message suggestions inject the text into the composer while action suggestions trigger a quick action.';
+$string['suggestion_mode_message'] = 'Send message';
+$string['suggestion_mode_action'] = 'Trigger quick action';
+$string['suggestion_target'] = 'Target / action key';
+$string['suggestion_target_help'] = 'For action suggestions specify the quick action key to execute. For message suggestions this can be left blank to reuse the text.';
+$string['suggestion_icon'] = 'Icon / emoji';
+$string['suggestion_enabled'] = 'Enabled';
+$string['suggestion_sortorder'] = 'Sort order';
+$string['suggestion_status'] = 'Status';
+$string['suggestion_target_required'] = 'Choose an action to trigger when the suggestion mode is set to “Trigger quick action”.';
+$string['suggestion_edit_heading'] = 'Edit suggestion';
+$string['suggestion_add_heading'] = 'Add suggestion';
+$string['suggestion_table_heading'] = 'Configured suggestions';
+$string['suggestion_saved'] = 'Suggestion saved.';
+$string['suggestion_deleted'] = 'Suggestion deleted.';
+$string['suggestion_delete_confirm'] = 'Delete the suggestion "{$a}"?';
+
+// Training console.
 $string['training'] = 'Training & learning';
+$string['training_intro'] = 'Experiment with intents, responses and quick actions without leaving the Moodle interface.';
+$string['training_message'] = 'Message to analyse';
+$string['training_logmessage'] = 'Log result to history';
+$string['training_logmessage_help'] = 'If enabled the message will be stored in the conversation log as if it was submitted from the widget.';
+$string['training_sessionid'] = 'Session identifier';
+$string['training_sessionid_help'] = 'Provide a session id to reuse an existing conversation, otherwise a fresh session will be generated.';
+$string['training_run'] = 'Run analysis';
+$string['training_logged'] = 'Stored in conversation log';
+$string['training_preview'] = 'Preview only';
+$string['training_result_heading'] = 'Analysis result';
+$string['training_result_status'] = 'Mode: {$a}';
+$string['training_result_intent'] = 'Matched intent: {$a}';
+$string['training_result_response'] = 'Response: {$a}';
+$string['training_result_session'] = 'Session: {$a}';
+$string['training_result_keywords'] = 'Keywords considered: {$a}';
+$string['training_context_heading'] = 'Widget context overview';
+$string['training_context_suggestions'] = 'Suggestion chips currently exposed:';
+$string['training_context_actions'] = 'Quick actions currently available:';
+$string['training_history_heading'] = 'Recent messages for this session';
+$string['training_result_time'] = 'Response time: {$a}';
+
+// Analytics dashboard.
 $string['analytics'] = 'Analytics and reports';
+$string['analytics_intro'] = 'Track engagement with the chatbot to understand how the assistant is used across the site.';
+$string['analytics_total_messages'] = 'Total messages logged';
+$string['analytics_total_sessions'] = 'Active sessions';
+$string['analytics_total_users'] = 'Unique users';
+$string['analytics_average_response'] = 'Average response time';
+$string['analytics_intents_heading'] = 'Intents usage';
+$string['analytics_messages'] = 'Messages';
+$string['analytics_intents_chart_title'] = 'Messages per intent';
+$string['analytics_activity_chart_title'] = 'Messages per day';
+$string['analytics_activity_heading'] = 'Recent activity';
+$string['analytics_feedback_heading'] = 'Feedback distribution';
+$string['analytics_feedback_unknown'] = 'Unspecified';
+
+// Dialogue viewer.
 $string['dialogues'] = 'Dialogue flows';
+$string['dialogue_filter_session'] = 'Session id';
+$string['dialogue_filter_userid'] = 'User id';
+$string['dialogue_filter_intent'] = 'Intent';
+$string['dialogue_filter_from'] = 'From date';
+$string['dialogue_filter_to'] = 'To date';
+$string['dialogue_filter_feedback'] = 'Only messages with feedback';
+$string['dialogue_filter_apply'] = 'Apply filters';
+$string['dialogue_filter_reset'] = 'Reset';
+$string['dialogue_detail_heading'] = 'Conversation for session {$a}';
+$string['dialogue_export'] = 'Export conversation';
+$string['dialogue_no_records'] = 'No conversation records matched the criteria.';
+$string['dialogue_session'] = 'Session';
+$string['viewdetails'] = 'View details';
+
+// Manual test console.
 $string['test_chatbot'] = 'Try the chatbot';
+$string['test_intro'] = 'Send messages as the current user to verify keywords, intents and exports. Messages are stored in the main conversation log.';
+$string['test_message'] = 'Message';
+$string['test_sessionid'] = 'Session id (optional)';
+$string['test_sessionid_help'] = 'Provide a custom session id to reuse an existing conversation. Leave empty to generate a new one.';
+$string['test_send'] = 'Send message';
+$string['test_result_heading'] = 'Server response';
+$string['test_result_response'] = 'Response: {$a}';
+$string['test_result_intent'] = 'Intent: {$a}';
+$string['test_result_session'] = 'Session: {$a}';
+$string['test_result_logid'] = 'Log id: {$a}';
+$string['test_result_time'] = 'Response time: {$a}';
+$string['test_suggestions_heading'] = 'Current suggestions';
+$string['test_quickactions_heading'] = 'Quick actions overview';
+$string['test_history_heading'] = 'Conversation history';
 
 // Feedback buttons.
 $string['chatbot_feedback_helpful'] = 'Helpful';
 $string['chatbot_feedback_not_helpful'] = 'Not helpful';
 $string['chatbot_feedback_thanks'] = 'Thanks for your feedback!';
+
+// Legacy strings kept for backwards compatibility (no longer displayed).
+$string['admin_placeholder'] = 'The management console is being prepared. The widget and web services are fully functional.';
+$string['admin_placeholder_help'] = 'Continue using the Site administration settings page to configure the chatbot in the meantime.';
+$string['analytics_and_reports'] = 'Analytics and reports';

--- a/local/chatbot/lang/es/local_chatbot.php
+++ b/local/chatbot/lang/es/local_chatbot.php
@@ -2,24 +2,22 @@
 // Este archivo forma parte de Moodle - http://moodle.org/
 //
 // Moodle es software libre: puedes redistribuirlo y/o modificarlo
-// bajo los términos de la Licencia Pública General de GNU publicada por
+// bajo los términos de la Licencia Pública General GNU publicada por
 // la Free Software Foundation, ya sea la versión 3 de la licencia o
 // (a tu elección) cualquier versión posterior.
 //
-// Moodle se distribuye con la esperanza de que sea útil,
+// Moodle se distribuye con la esperanza de que resulte útil,
 // pero SIN NINGUNA GARANTÍA; ni siquiera la garantía implícita
-// de COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR. Véase la
-// Licencia Pública General de GNU para más detalles.
+// de COMERCIABILIDAD o IDONEIDAD PARA UN PROPÓSITO PARTICULAR.
+// Consulta la Licencia Pública General GNU para más detalles.
 //
-// Deberías haber recibido una copia de la Licencia Pública General de GNU
-// junto con Moodle. Si no, consulta <http://www.gnu.org/licenses/>.
+// Deberías haber recibido una copia de la Licencia Pública General GNU
+// junto con Moodle. En caso contrario, consulta <http://www.gnu.org/licenses/>.
 
 /**
  * Cadenas en español para el plugin local_chatbot.
  *
  * @package    local_chatbot
- * @copyright  2024 Moodle Community
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 o posterior
  */
 
 $string['pluginname'] = 'Asistente de chatbot';
@@ -33,9 +31,9 @@ $string['chatbot:export'] = 'Exportar conversaciones del chatbot';
 $string['chatbot_title'] = 'Asistente virtual';
 $string['chatbot_placeholder'] = 'Escribe tu mensaje…';
 $string['chatbot_send'] = 'Enviar';
-$string['chatbot_error'] = 'Lo sentimos, ha ocurrido un error. Intenta nuevamente.';
+$string['chatbot_error'] = 'Lo sentimos, ocurrió un error. Intenta nuevamente.';
 $string['chatbot_typing_indicator'] = 'El asistente está escribiendo…';
-$string['chatbot_status_online'] = 'En línea y listo para ayudar';
+$string['chatbot_status_online'] = 'En línea y listo para ayudarte';
 $string['chatbot_toggle_label'] = 'Hablar con {$a}';
 $string['chatbot_voice_input_label'] = 'Entrada de voz';
 $string['chatbot_emoji_picker_label'] = 'Selector de emojis';
@@ -43,9 +41,9 @@ $string['chatbot_export_conversation_label'] = 'Exportar conversación';
 $string['chatbot_minimize'] = 'Minimizar';
 $string['chatbot_close'] = 'Cerrar';
 $string['chatbot_quick_actions_region'] = 'Accesos rápidos del chatbot';
-$string['chatbot_suggestions_region'] = 'Sugerencias';
+$string['chatbot_suggestions_region'] = 'Sugerencias del asistente';
 $string['chatbot_welcome_template'] = '¡Hola {name}! Estoy aquí para acompañarte en Moodle.';
-$string['default_nomatch'] = 'Aún no tengo información sobre eso. ¿Podrías reformular tu pregunta?';
+$string['default_nomatch'] = 'Todavía no tengo información sobre eso. ¿Podrías reformular la pregunta?';
 
 // Sugerencias y accesos rápidos.
 $string['chatbot_suggestion_courses'] = '¿Dónde veo mis cursos?';
@@ -55,13 +53,16 @@ $string['chatbot_action_profile'] = 'Mi perfil';
 $string['chatbot_action_profile_desc'] = 'Abre tu página de perfil';
 $string['chatbot_action_calendar'] = 'Calendario';
 $string['chatbot_action_calendar_desc'] = 'Abre la vista del calendario';
+$string['chatbot_action_support'] = 'Centro de soporte';
+$string['chatbot_action_support_desc'] = 'Muestra las opciones de contacto del soporte institucional';
 $string['chatbot_action_generic'] = 'Acción ejecutada: {$a}';
 
-// Respuestas rápidas.
+// Respuestas automáticas.
 $string['chatbot_response_greeting'] = '¡Hola! 👋 ¿En qué puedo ayudarte hoy?';
-$string['chatbot_response_help'] = 'Puedo ayudarte a encontrar cursos, calificaciones y enlaces útiles. Por ejemplo pregunta "¿Dónde veo mis calificaciones?"';
-$string['chatbot_response_courses'] = 'Abre el menú "Mis cursos" en la parte superior para ver tus asignaturas inscritas.';
+$string['chatbot_response_help'] = 'Puedo orientarte sobre cursos, calificaciones y enlaces útiles. Por ejemplo pregunta “¿Dónde veo mis calificaciones?”';
+$string['chatbot_response_courses'] = 'Abre el menú “Mis cursos” en la parte superior para ver tus asignaturas inscritas.';
 $string['chatbot_response_grades'] = 'Accede al reporte de calificaciones desde el menú de usuario o dentro de cada curso.';
+$string['chatbot_response_support'] = 'Puedes contactar al equipo de soporte mediante el centro de ayuda o escribiendo al correo oficial de asistencia.';
 
 // Exportación.
 $string['chatbot_export_heading'] = 'Historial de la conversación';
@@ -89,7 +90,7 @@ $string['theme_modern'] = 'Moderno';
 $string['theme_minimal'] = 'Minimalista';
 $string['theme_dark'] = 'Oscuro';
 $string['setting_welcome'] = 'Mensaje de bienvenida';
-$string['setting_welcome_desc'] = 'Mensaje que se muestra al abrir el chatbot por primera vez. Usa {name} para el nombre del usuario.';
+$string['setting_welcome_desc'] = 'Mensaje mostrado la primera vez que se abre el chatbot. Usa {name} para personalizar con el nombre de la persona.';
 $string['setting_nomatch'] = 'Respuesta por defecto';
 $string['setting_nomatch_desc'] = 'Mensaje enviado cuando el chatbot no reconoce la pregunta.';
 $string['setting_maxlength'] = 'Longitud máxima del mensaje';
@@ -97,17 +98,155 @@ $string['setting_maxlength_desc'] = 'Limita el número de caracteres que puede e
 $string['setting_allow_export'] = 'Permitir exportar conversaciones';
 $string['setting_allow_export_desc'] = 'Muestra el botón de exportar cuando el usuario tiene el permiso correspondiente.';
 
-// Pantallas administrativas provisionales.
-$string['admin_placeholder'] = 'El panel de gestión está en construcción. El widget y los servicios ya están disponibles.';
-$string['admin_placeholder_help'] = 'Mientras tanto utiliza la página de configuración en Administración del sitio → Plugins → Plugins locales → Asistente de chatbot.';
+// Gestión de intenciones.
 $string['manage_intents'] = 'Gestionar intenciones';
+$string['intents_intro'] = 'Administra las intenciones que alimentan el clasificador del chatbot. Las palabras clave se evalúan en orden y una intención puede actuar como fallback global.';
+$string['intent_name'] = 'Nombre de la intención';
+$string['intent_keywords'] = 'Palabras clave';
+$string['intent_keywords_help'] = 'Introduce una palabra clave por línea. La coincidencia no distingue mayúsculas de minúsculas.';
+$string['intent_response'] = 'Respuesta a enviar';
+$string['intent_fallback'] = 'Usar como intención por defecto';
+$string['intent_fallback_help'] = 'Si está activado esta respuesta se devolverá cuando ninguna otra intención coincida.';
+$string['intent_enabled'] = 'Habilitada';
+$string['intent_sortorder'] = 'Orden';
+$string['intent_status'] = 'Estado';
+$string['intent_status_fallback'] = 'Fallback';
+$string['intent_no_keywords'] = 'Sin palabras clave';
+$string['intent_keywords_required'] = 'Proporciona al menos una palabra clave o marca la intención como fallback.';
+$string['intent_unknown'] = 'Sin clasificar';
+$string['intent_edit_heading'] = 'Editar intención';
+$string['intent_add_heading'] = 'Nueva intención';
+$string['intent_table_heading'] = 'Intenciones configuradas';
+$string['intent_saved'] = 'La intención se guardó correctamente.';
+$string['intent_deleted'] = 'La intención se eliminó.';
+$string['intent_delete_confirm'] = '¿Seguro que deseas eliminar la intención "{$a}"?';
+
+// Entidades (accesos rápidos y sugerencias).
 $string['manage_entities'] = 'Gestionar entidades';
+$string['entities_intro'] = 'Configura los accesos rápidos y sugerencias que ve el usuario en el widget.';
+$string['entities_quickactions_tab'] = 'Accesos rápidos';
+$string['entities_suggestions_tab'] = 'Sugerencias';
+$string['quickaction_actionkey'] = 'Clave de acción';
+$string['quickaction_name'] = 'Etiqueta';
+$string['quickaction_type'] = 'Tipo de acción';
+$string['quickaction_type_help'] = 'Define si la acción navega a una página, rellena el cuadro de texto o responde desde el servidor.';
+$string['quickaction_type_navigate'] = 'Navegar a una página';
+$string['quickaction_type_inject'] = 'Prefijar un mensaje';
+$string['quickaction_type_server'] = 'Respuesta del servidor';
+$string['quickaction_payload'] = 'Contenido';
+$string['quickaction_payload_help'] = 'Para navegar usa rutas relativas como /user/profile.php?id={userid}. Para los otros tipos ingresa el texto a mostrar.';
+$string['quickaction_description'] = 'Descripción';
+$string['quickaction_icon'] = 'Icono / emoji';
+$string['quickaction_icon_help'] = 'Opcional: emoji o texto corto usado como icono en el widget.';
+$string['quickaction_enabled'] = 'Habilitada';
+$string['quickaction_sortorder'] = 'Orden';
+$string['quickaction_status'] = 'Estado';
+$string['quickaction_payload_required'] = 'Debes indicar una URL o ruta para las acciones de navegación.';
+$string['quickaction_payload_text_required'] = 'Debes indicar el texto que enviará esta acción.';
+$string['quickaction_actionkey_unique'] = 'La clave de acción debe ser única.';
+$string['quickaction_edit_heading'] = 'Editar acceso rápido';
+$string['quickaction_add_heading'] = 'Nuevo acceso rápido';
+$string['quickaction_table_heading'] = 'Accesos rápidos configurados';
+$string['quickaction_saved'] = 'Acceso rápido guardado.';
+$string['quickaction_deleted'] = 'Acceso rápido eliminado.';
+$string['quickaction_delete_confirm'] = '¿Eliminar el acceso rápido "{$a}"?';
+
+$string['suggestion_text'] = 'Texto de la sugerencia';
+$string['suggestion_mode'] = 'Comportamiento';
+$string['suggestion_mode_help'] = 'Las sugerencias tipo mensaje rellenan el cuadro de texto; las de tipo acción ejecutan un acceso rápido.';
+$string['suggestion_mode_message'] = 'Enviar mensaje';
+$string['suggestion_mode_action'] = 'Ejecutar acceso rápido';
+$string['suggestion_target'] = 'Destino / clave de acción';
+$string['suggestion_target_help'] = 'Para sugerencias de acción indica la clave del acceso rápido a ejecutar. Para mensajes puede quedar vacío.';
+$string['suggestion_icon'] = 'Icono / emoji';
+$string['suggestion_enabled'] = 'Habilitada';
+$string['suggestion_sortorder'] = 'Orden';
+$string['suggestion_status'] = 'Estado';
+$string['suggestion_target_required'] = 'Selecciona la acción a ejecutar cuando el modo sea “Ejecutar acceso rápido”.';
+$string['suggestion_edit_heading'] = 'Editar sugerencia';
+$string['suggestion_add_heading'] = 'Nueva sugerencia';
+$string['suggestion_table_heading'] = 'Sugerencias configuradas';
+$string['suggestion_saved'] = 'Sugerencia guardada.';
+$string['suggestion_deleted'] = 'Sugerencia eliminada.';
+$string['suggestion_delete_confirm'] = '¿Eliminar la sugerencia "{$a}"?';
+
+// Consola de entrenamiento.
 $string['training'] = 'Entrenamiento y aprendizaje';
+$string['training_intro'] = 'Prueba mensajes y revisa cómo responden las intenciones sin salir de Moodle.';
+$string['training_message'] = 'Mensaje a analizar';
+$string['training_logmessage'] = 'Guardar en el historial';
+$string['training_logmessage_help'] = 'Si está activado el mensaje se almacenará en la tabla de conversaciones como si llegara desde el widget.';
+$string['training_sessionid'] = 'Identificador de sesión';
+$string['training_sessionid_help'] = 'Introduce un identificador para continuar una conversación existente o déjalo vacío para crear una nueva sesión.';
+$string['training_run'] = 'Analizar mensaje';
+$string['training_logged'] = 'Guardado en el historial';
+$string['training_preview'] = 'Solo vista previa';
+$string['training_result_heading'] = 'Resultado del análisis';
+$string['training_result_status'] = 'Modo: {$a}';
+$string['training_result_intent'] = 'Intención detectada: {$a}';
+$string['training_result_response'] = 'Respuesta: {$a}';
+$string['training_result_session'] = 'Sesión: {$a}';
+$string['training_result_keywords'] = 'Palabras clave consideradas: {$a}';
+$string['training_context_heading'] = 'Contexto del widget';
+$string['training_context_suggestions'] = 'Sugerencias visibles:';
+$string['training_context_actions'] = 'Accesos rápidos disponibles:';
+$string['training_history_heading'] = 'Mensajes recientes de esta sesión';
+$string['training_result_time'] = 'Tiempo de respuesta: {$a}';
+
+// Panel de analíticas.
 $string['analytics'] = 'Analíticas e informes';
+$string['analytics_intro'] = 'Monitorea el uso del chatbot para comprender su adopción en la plataforma.';
+$string['analytics_total_messages'] = 'Mensajes registrados';
+$string['analytics_total_sessions'] = 'Sesiones activas';
+$string['analytics_total_users'] = 'Usuarios únicos';
+$string['analytics_average_response'] = 'Tiempo de respuesta promedio';
+$string['analytics_intents_heading'] = 'Uso de intenciones';
+$string['analytics_messages'] = 'Mensajes';
+$string['analytics_intents_chart_title'] = 'Mensajes por intención';
+$string['analytics_activity_chart_title'] = 'Mensajes por día';
+$string['analytics_activity_heading'] = 'Actividad reciente';
+$string['analytics_feedback_heading'] = 'Distribución de retroalimentación';
+$string['analytics_feedback_unknown'] = 'Sin especificar';
+
+// Visualizador de diálogos.
 $string['dialogues'] = 'Flujos de diálogo';
+$string['dialogue_filter_session'] = 'Id. de sesión';
+$string['dialogue_filter_userid'] = 'Id. de usuario';
+$string['dialogue_filter_intent'] = 'Intención';
+$string['dialogue_filter_from'] = 'Desde';
+$string['dialogue_filter_to'] = 'Hasta';
+$string['dialogue_filter_feedback'] = 'Solo mensajes con retroalimentación';
+$string['dialogue_filter_apply'] = 'Aplicar filtros';
+$string['dialogue_filter_reset'] = 'Restablecer';
+$string['dialogue_detail_heading'] = 'Conversación de la sesión {$a}';
+$string['dialogue_export'] = 'Exportar conversación';
+$string['dialogue_no_records'] = 'No se encontraron conversaciones con los filtros indicados.';
+$string['dialogue_session'] = 'Sesión';
+$string['viewdetails'] = 'Ver detalles';
+
+// Consola de pruebas manuales.
 $string['test_chatbot'] = 'Probar el chatbot';
+$string['test_intro'] = 'Envía mensajes como el usuario actual para verificar coincidencias, respuestas y exportaciones. Los mensajes se guardan en el historial principal.';
+$string['test_message'] = 'Mensaje';
+$string['test_sessionid'] = 'Id. de sesión (opcional)';
+$string['test_sessionid_help'] = 'Introduce un identificador personalizado para reutilizar una conversación existente. Déjalo vacío para generar uno nuevo.';
+$string['test_send'] = 'Enviar mensaje';
+$string['test_result_heading'] = 'Respuesta del servidor';
+$string['test_result_response'] = 'Respuesta: {$a}';
+$string['test_result_intent'] = 'Intención: {$a}';
+$string['test_result_session'] = 'Sesión: {$a}';
+$string['test_result_logid'] = 'Registro: {$a}';
+$string['test_result_time'] = 'Tiempo de respuesta: {$a}';
+$string['test_suggestions_heading'] = 'Sugerencias actuales';
+$string['test_quickactions_heading'] = 'Resumen de accesos rápidos';
+$string['test_history_heading'] = 'Historial de la conversación';
 
 // Botones de retroalimentación.
 $string['chatbot_feedback_helpful'] = 'Útil';
 $string['chatbot_feedback_not_helpful'] = 'No útil';
 $string['chatbot_feedback_thanks'] = '¡Gracias por tu comentario!';
+
+// Cadenas heredadas (compatibilidad).
+$string['admin_placeholder'] = 'El panel de gestión está en construcción. El widget y los servicios ya están disponibles.';
+$string['admin_placeholder_help'] = 'Mientras tanto utiliza la página de configuración en Administración del sitio → Plugins → Plugins locales → Asistente de chatbot.';
+$string['analytics_and_reports'] = 'Analíticas e informes';

--- a/local/chatbot/lib.php
+++ b/local/chatbot/lib.php
@@ -29,6 +29,187 @@ use core\hook\output\before_footer_html_generation;
 require_once($CFG->dirroot . '/user/lib.php');
 
 /**
+ * Reset runtime caches for dynamic chatbot data.
+ */
+function local_chatbot_reset_runtime_cache(): void {
+    local_chatbot_get_intents(true);
+    local_chatbot_get_suggestions(true);
+    local_chatbot_get_quick_actions(true);
+}
+
+/**
+ * Fetch chatbot intents.
+ *
+ * @param bool $forcereload
+ * @return array
+ */
+function local_chatbot_get_intents(bool $forcereload = false): array {
+    global $DB;
+
+    static $cache = null;
+    if ($forcereload) {
+        $cache = null;
+    }
+
+    if ($cache === null) {
+        $records = $DB->get_records('local_chatbot_intents', ['enabled' => 1], 'sortorder ASC, name ASC');
+        $cache = array_values($records);
+    }
+
+    return $cache;
+}
+
+/**
+ * Parse keyword string into an array.
+ *
+ * @param string|null $keywords
+ * @return array
+ */
+function local_chatbot_parse_keywords(?string $keywords): array {
+    if ($keywords === null) {
+        return [];
+    }
+
+    $lines = preg_split('/[\n,]+/', core_text::strtolower($keywords));
+    $lines = array_map('trim', $lines);
+    $lines = array_filter($lines, static function($value) {
+        return $value !== '';
+    });
+
+    return array_values(array_unique($lines));
+}
+
+/**
+ * Classify a message and return the response configuration.
+ *
+ * @param string $message
+ * @return array{intent:?stdClass,response:string,matched:string}
+ */
+function local_chatbot_classify_message(string $message): array {
+    $message = trim($message);
+    $lcmessage = core_text::strtolower($message);
+
+    $fallback = null;
+    foreach (local_chatbot_get_intents() as $intent) {
+        if (!empty($intent->isfallback)) {
+            $fallback = $intent;
+            continue;
+        }
+
+        foreach (local_chatbot_parse_keywords($intent->keywords) as $keyword) {
+            if ($keyword !== '' && core_text::strpos($lcmessage, $keyword) !== false) {
+                return [$intent, $intent->response, $keyword];
+            }
+        }
+    }
+
+    if ($fallback) {
+        return [$fallback, $fallback->response, ''];
+    }
+
+    $response = (string)(get_config('local_chatbot', 'default_nomatch')
+        ?: get_string('default_nomatch', 'local_chatbot'));
+
+    return [null, $response, ''];
+}
+
+/**
+ * Retrieve configured suggestions.
+ *
+ * @param bool $forcereload
+ * @return array
+ */
+function local_chatbot_get_suggestions(bool $forcereload = false): array {
+    global $DB;
+
+    static $cache = null;
+    if ($forcereload) {
+        $cache = null;
+    }
+
+    if ($cache === null) {
+        $records = $DB->get_records('local_chatbot_suggestions', ['enabled' => 1], 'sortorder ASC, text ASC');
+        $cache = array_values($records);
+    }
+
+    return $cache;
+}
+
+/**
+ * Resolve a quick action URL replacing special tokens.
+ *
+ * @param string $payload
+ * @param stdClass $user
+ * @param int $courseid
+ * @return moodle_url
+ */
+function local_chatbot_resolve_quick_action_url(string $payload, stdClass $user, int $courseid): moodle_url {
+    global $CFG;
+
+    $replacements = [
+        '{userid}' => $user->id,
+        '{courseid}' => $courseid ?: 0,
+        '{wwwroot}' => $CFG->wwwroot,
+    ];
+
+    $resolved = str_replace(array_keys($replacements), array_values($replacements), trim($payload));
+    if ($resolved === '') {
+        return new moodle_url('/');
+    }
+
+    return new moodle_url($resolved);
+}
+
+/**
+ * Retrieve quick actions.
+ *
+ * @param bool $forcereload
+ * @return array
+ */
+function local_chatbot_get_quick_actions(bool $forcereload = false): array {
+    global $DB, $USER, $PAGE;
+
+    static $cache = null;
+    if ($forcereload) {
+        $cache = null;
+    }
+
+    if ($cache === null) {
+        $records = $DB->get_records('local_chatbot_quickacts', ['enabled' => 1], 'sortorder ASC, name ASC');
+        $courseid = $PAGE->course->id ?? 0;
+
+        $cache = [];
+        foreach ($records as $record) {
+            $action = [
+                'actionkey' => $record->actionkey,
+                'label' => $record->name,
+                'description' => (string)$record->description,
+                'icon' => (string)$record->icon,
+                'type' => $record->type,
+                'message' => '',
+                'url' => null,
+            ];
+
+            switch ($record->type) {
+                case 'inject':
+                case 'server':
+                    $action['message'] = (string)$record->payload;
+                    break;
+                case 'navigate':
+                default:
+                    $action['url'] = local_chatbot_resolve_quick_action_url($record->payload ?? '/', $USER, $courseid);
+                    $action['type'] = 'navigate';
+                    break;
+            }
+
+            $cache[] = $action;
+        }
+    }
+
+    return $cache;
+}
+
+/**
  * Legacy callback stub kept for completeness.
  */
 function local_chatbot_extend_navigation() {
@@ -213,44 +394,8 @@ function local_chatbot_process_message(string $message, ?string $sessionid = nul
     $sessionid = $sessionid ?: local_chatbot_generate_sessionid($USER->id);
     $start = microtime(true);
 
-    $intent = 'general';
-    $response = '';
-
-    $lcmessage = core_text::strtolower($message);
-    $responses = [
-        'greeting' => [
-            'keywords' => ['hola', 'hello', 'buenos', 'buenas', 'hi'],
-            'response' => get_string('chatbot_response_greeting', 'local_chatbot'),
-        ],
-        'help' => [
-            'keywords' => ['ayuda', 'help', 'assist', 'no puedo'],
-            'response' => get_string('chatbot_response_help', 'local_chatbot'),
-        ],
-        'courses' => [
-            'keywords' => ['curso', 'course', 'materia', 'class'],
-            'response' => get_string('chatbot_response_courses', 'local_chatbot'),
-        ],
-        'grades' => [
-            'keywords' => ['nota', 'grade', 'calificación'],
-            'response' => get_string('chatbot_response_grades', 'local_chatbot'),
-        ],
-    ];
-
-    foreach ($responses as $label => $data) {
-        foreach ($data['keywords'] as $keyword) {
-            if (core_text::strpos($lcmessage, $keyword) !== false) {
-                $intent = $label;
-                $response = $data['response'];
-                break 2;
-            }
-        }
-    }
-
-    if ($response === '') {
-        $intent = 'nomatch';
-        $response = (string)(get_config('local_chatbot', 'default_nomatch')
-            ?: get_string('default_nomatch', 'local_chatbot'));
-    }
+    [$intentrecord, $response, $matchedkeyword] = local_chatbot_classify_message($message);
+    $intent = $intentrecord ? (string)$intentrecord->name : 'nomatch';
 
     $responsetime = (int)round((microtime(true) - $start) * 1000);
 
@@ -261,7 +406,10 @@ function local_chatbot_process_message(string $message, ?string $sessionid = nul
         'response' => $response,
         'intent' => $intent,
         'responsetime' => $responsetime,
-        'metadata' => json_encode(['language' => current_language()]),
+        'metadata' => json_encode([
+            'language' => current_language(),
+            'matchedkeyword' => $matchedkeyword,
+        ]),
         'timecreated' => time(),
     ];
     $logid = $DB->insert_record('local_chatbot_logs', $record);
@@ -277,42 +425,39 @@ function local_chatbot_process_message(string $message, ?string $sessionid = nul
 }
 
 /**
- * Return contextual suggestions.
+ * Preview a message without logging it.
  *
+ * @param string $message
  * @return array
  */
-function local_chatbot_get_suggestions(): array {
+function local_chatbot_preview_message(string $message): array {
+    [$intent, $response, $matchedkeyword] = local_chatbot_classify_message($message);
+
     return [
-        ['text' => get_string('chatbot_suggestion_courses', 'local_chatbot'), 'action' => 'show_courses', 'icon' => '📚'],
-        ['text' => get_string('chatbot_suggestion_grades', 'local_chatbot'), 'action' => 'show_grades', 'icon' => '📊'],
-        ['text' => get_string('chatbot_suggestion_support', 'local_chatbot'), 'action' => '', 'icon' => '🆘'],
+        'intent' => $intent ? $intent->name : 'nomatch',
+        'response' => $response,
+        'matchedkeyword' => $matchedkeyword,
+        'intentrecord' => $intent,
     ];
 }
 
 /**
- * Return contextual quick actions.
+ * Return contextual suggestions.
  *
  * @return array
  */
-function local_chatbot_get_quick_actions(): array {
-    global $USER;
+function local_chatbot_get_suggestions_payload(): array {
+    $results = [];
+    foreach (local_chatbot_get_suggestions() as $suggestion) {
+        $results[] = [
+            'text' => $suggestion->text,
+            'mode' => $suggestion->mode,
+            'target' => (string)$suggestion->target,
+            'icon' => (string)$suggestion->icon,
+        ];
+    }
 
-    return [
-        [
-            'icon' => '👤',
-            'label' => get_string('chatbot_action_profile', 'local_chatbot'),
-            'action' => 'navigate',
-            'description' => get_string('chatbot_action_profile_desc', 'local_chatbot'),
-            'url' => new moodle_url('/user/profile.php', ['id' => $USER->id]),
-        ],
-        [
-            'icon' => '🗓️',
-            'label' => get_string('chatbot_action_calendar', 'local_chatbot'),
-            'action' => 'navigate',
-            'description' => get_string('chatbot_action_calendar_desc', 'local_chatbot'),
-            'url' => new moodle_url('/calendar/view.php', ['view' => 'month']),
-        ],
-    ];
+    return $results;
 }
 
 /**

--- a/local/chatbot/version.php
+++ b/local/chatbot/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_chatbot';
-$plugin->version   = 2025012503;
+$plugin->version   = 2025020100;
 $plugin->requires  = 2023100900; // Moodle 4.3.
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.0.1';
+$plugin->release   = '1.1.0';
 


### PR DESCRIPTION
## Summary
- replace the placeholder administration screens with fully functional pages for intents, entities, analytics, dialogues, training and manual testing
- add new database tables and forms to manage intents, quick actions and suggestions that drive the widget configuration and web services
- update the widget, web services, documentation and translations to consume the dynamic data and prepare the 1.1.0 release

## Testing
- php -l local/chatbot/lib.php
- php -l local/chatbot/externallib.php
- php -l local/chatbot/admin/analytics.php
- php -l local/chatbot/admin/dialogues.php
- php -l local/chatbot/admin/entities.php
- php -l local/chatbot/admin/intents.php
- php -l local/chatbot/admin/test.php
- php -l local/chatbot/admin/training.php
- for file in local/chatbot/classes/form/*.php; do php -l "$file"; done
- php -l local/chatbot/db/upgrade.php

------
https://chatgpt.com/codex/tasks/task_e_68d6f652bad8832aa1a06ccfb6d26241